### PR TITLE
fix: order act instance by start time

### DIFF
--- a/src/main/java/io/camunda/migrator/CamundaMigrator.java
+++ b/src/main/java/io/camunda/migrator/CamundaMigrator.java
@@ -343,7 +343,8 @@ public class CamundaMigrator {
   }
 
   private void migrateFlowNodes() {
-    HistoricActivityInstanceQueryImpl legacyFlowNodeQuery = (HistoricActivityInstanceQueryImpl) historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceId().asc();
+    HistoricActivityInstanceQueryImpl legacyFlowNodeQuery = (HistoricActivityInstanceQueryImpl) historyService.createHistoricActivityInstanceQuery()
+                                                             .orderByHistoricActivityInstanceStartTime().asc();
 
     String latestLegacyId = flowNodeMapper.findLatestId();
     if (latestLegacyId != null) {


### PR DESCRIPTION
Context: instances depend on each other. Otherwise I get error:
```
java.lang.NullPointerException: Cannot invoke "io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel.processInstanceKey()" because the return value of "io.camunda.migrator.CamundaMigrator.findProcessInstanceKey(String)" is null
        at io.camunda.migrator.CamundaMigrator.lambda$migrateProcessInstances$2(CamundaMigrator.java:221) ~[classes/:na]
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1596) ~[na:na]
        at io.camunda.migrator.CamundaMigrator.migrateProcessInstances(CamundaMigrator.java:212) ~[classes/:na]
        at io.camunda.migrator.CamundaMigrator.migrateAllHistoricProcessInstances(CamundaMigrator.java:117) ~[classes/:na]
        at io.camunda.migrator.service.C7MigrationService.execute(C7MigrationService.java:104) ~[classes/:na]
        at io.camunda.migrator.Main.main(Main.java:21) ~[classes/:na]
```