### PR TITLE
feat(release): add release workflow

### DIFF
--- a/.github/workflows/release-c7-data-migrator.yml
+++ b/.github/workflows/release-c7-data-migrator.yml
@@ -1,7 +1,6 @@
 name: Release C7 Data Migrator
 
 on:
-  pull_request:
   workflow_dispatch:
     inputs:
       RELEASE_VERSION:
@@ -12,9 +11,10 @@ on:
         required: true
         description: "Next development version"
         default: "0.1.0-SNAPSHOT"
-#      RELEASE_BRANCH:
-#        required: true
-#        default: "release/0.0.0"
+      RELEASE_BRANCH:
+        description: "The branch to be used for this release."
+        required: true
+        default: "release/0.0.0"
       IS_DRY_RUN:
         description: "Whether to perform a dry release where no changes or artifacts are pushed, defaults to true."
         required: true
@@ -25,7 +25,7 @@ defaults:
     shell: bash
 
 env:
-#  RELEASE_BRANCH: ${{ inputs.releaseBranch != '' && inputs.releaseBranch || format('release-{0}', inputs.releaseVersion) }}
+  RELEASE_BRANCH: ${{ inputs.RELEASE_BRANCH != '' && inputs.RELEASE_BRANCH || format('release-{0}', inputs.RELEASE_VERSION) }}
   RELEASE_VERSION: ${{ inputs.RELEASE_VERSION }}
   IS_DRY_RUN: ${{ inputs.IS_DRY_RUN }}
   DEVELOPMENT_VERSION: ${{ inputs.DEVELOPMENT_VERSION }}
@@ -41,7 +41,7 @@ jobs:
       - name: Output Inputs
         run: echo "${{ toJSON(github.event.inputs) }}"
 
-      # This step generates a GitHub App token to be used in Git operations as a workaround  for
+      # This step generates a GitHub App token to be used in Git operations as a workaround for
       # the known GitHub issue described in https://github.com/camunda/camunda/issues/28522
       - name: Generate GitHub token
         id: github-token
@@ -59,9 +59,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
-          ref: 4990-add-release-workflow
-#          TODO adjust branch after testing
-#          ref: ${{ RELEASE_BRANCH }}
+          ref: ${{ RELEASE_BRANCH }}
           # Overriding the default GITHUB_TOKEN with a GitHub App token in order to workaround
           # the known GitHub issue described in https://github.com/camunda/camunda/issues/28522
           # NOTES:
@@ -126,66 +124,40 @@ jobs:
           # Preparing the maven release
           # https://maven.apache.org/maven-release/maven-release-plugin/prepare-mojo.html
           # https://maven.apache.org/maven-release/maven-release-plugin/usage/prepare-release.html
-          #
-          # -DpreparationGoals
-          #   Goals to run as part of the preparation step, after transformation but before committing. Space delimited.
-          #   Default is 'clean verify'; We want to skip all the checks and packaging (as it will be done again later) so we set it to empty
-          #
-          # -Darguments
-          #   Additional arguments to pass to the Maven executions, separated by spaces.
-          #   Per default it is not required, but the release plugin is configured in the camunda release plugin (and this property is used)
-          #   This is the reason why we have to set it at least as empty string.
           mvn release:prepare -B \
             -Dresume=false \
-            -Dtag="0.1.0-alpha1-rc1" \
-            -DreleaseVersion="0.1.0-alpha1-rc1" \
-            -DdevelopmentVersion="0.1.0-SNAPSHOT" \
-            -DpushChanges=false \
-            -DremoteTagging=false \
+            -Dtag=${RELEASE_VERSION} \
+            -DreleaseVersion=${RELEASE_VERSION} \
+            -DdevelopmentVersion=${DEVELOPMENT_VERSION} \
+            -DpushChanges=${PUSH_CHANGES} \
+            -DremoteTagging=${PUSH_CHANGES} \
             -DignoreSnapshots=true \
-            -Darguments='-DskipTests=true -Dgpg.passphrase="${{ steps.secrets.outputs
-          .MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}'
+            -Darguments='-Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}"'
 
-      - name: Collect Release artifacts
+      - name: Collect Release Artifacts
         id: release-artifacts
         run: |
           ARTIFACT_DIR=$(mktemp -d)
-          cp assembly/target/c7-data-migrator-assembly-0.1.0-alpha1-rc1.tar.gz "${ARTIFACT_DIR}/"
-          cp assembly/target/c7-data-migrator-assembly-0.1.0-alpha1-rc1.zip "${ARTIFACT_DIR}/"
+          cp assembly/target/c7-data-migrator-assembly-${RELEASE_VERSION}.tar.gz "${ARTIFACT_DIR}/"
+          cp assembly/target/c7-data-migrator-assembly-${RELEASE_VERSION}.zip "${ARTIFACT_DIR}/"
           echo "dir=${ARTIFACT_DIR}" >> $GITHUB_OUTPUT
-          #          TODO adjust after testing
-          #          cp assembly/target/c7-data-migrator-assembly-${RELEASE_VERSION}.tar.gz "${ARTIFACT_DIR}/"
-          #          cp assembly/target/c7-data-migrator-assembly-${RELEASE_VERSION}.zip "${ARTIFACT_DIR}/"
-          
+
       - name: Upload Release Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: release-artifacts-0.1.0-alpha1-rc1 # TODO adjust after testing  name: release-artifacts-${{ inputs.releaseVersion }}
+          name: release-artifacts-${{ RELEASE_VERSION }}
           path: ${{ steps.release-artifacts.outputs.dir }}
-          retention-days: 5 # TODO clarify retention policy
+          retention-days: 14
 
-#          TODO undo changes after testing
-#          mvn release:prepare -B \
-#            -Dresume=false \
-#            -Dtag=${RELEASE_VERSION} \
-#            -DreleaseVersion=${RELEASE_VERSION} \
-#            -DdevelopmentVersion=${DEVELOPMENT_VERSION} \
-#            -DpushChanges=${PUSH_CHANGES} \
-#            -DremoteTagging=${PUSH_CHANGES} \
-#            -DignoreSnapshots=true \
-#            -DpreparationGoals="" \
-#            -Darguments='-Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}'
-
-#      - name: Maven Perform Release
-#        id: maven-perform-release
-#        env:
-#          SKIP_REPO_DEPLOY: ${{ IS_DRY_RUN }}
-#        run: |
-#          # Perform a maven release
-#          # https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html
-#          # https://maven.apache.org/maven-release/maven-release-plugin/usage/perform-release.html
-#
-#          mvn release:perform -B \
-#            -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}" \
-#            -DlocalCheckout=${{ IS_DRY_RUN }} \
-#            -Darguments='-DskipTests=true -Dskip.central.release=${SKIP_REPO_DEPLOY} -Dskip.camunda.release=${SKIP_REPO_DEPLOY} -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}"
+      - name: Maven Perform Release
+        id: maven-perform-release
+        env:
+          SKIP_REPO_DEPLOY: ${{ IS_DRY_RUN }}
+        run: |
+          # Perform a maven release
+          # https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html
+          # https://maven.apache.org/maven-release/maven-release-plugin/usage/perform-release.html
+          mvn release:perform -B \
+            -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}" \
+            -DlocalCheckout=${{ IS_DRY_RUN }} \
+            -Darguments='-DskipTests=true -Dskip.central.release=${SKIP_REPO_DEPLOY} -Dskip.camunda.release=${SKIP_REPO_DEPLOY} -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}"'

--- a/.github/workflows/release-c7-data-migrator.yml
+++ b/.github/workflows/release-c7-data-migrator.yml
@@ -104,20 +104,6 @@ jobs:
         with:
           secrets: ${{ toJSON(secrets) }}
 
-      # TODO camunda/camunda-bpm-platform/issues/4993
-      # Temp build migrator branch in platform
-      - name: Clone Platform
-        run: |
-          cd ../
-          git clone https://github.com/camunda/camunda-bpm-platform.git
-
-      - name: Build feature branch
-        run: |
-          cd ../camunda-bpm-platform/engine
-          git checkout poc-data-migrator
-          mvn clean install -DskipTests --batch-mode
-      # End of Temp build migrator branch in platform
-      
       - name: Maven Prepare Release
         id: maven-prepare-release
         run: |

--- a/.github/workflows/release-c7-data-migrator.yml
+++ b/.github/workflows/release-c7-data-migrator.yml
@@ -1,0 +1,191 @@
+name: Release C7 Data Migrator
+
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      RELEASE_VERSION:
+        description: "The version to be built and released. Defaults to 0.0.0."
+        required: true
+        default: "0.0.0"
+      DEVELOPMENT_VERSION:
+        required: true
+        description: "Next development version"
+        default: "0.1.0-SNAPSHOT"
+#      RELEASE_BRANCH:
+#        required: true
+#        default: "release/0.0.0"
+      IS_DRY_RUN:
+        description: "Whether to perform a dry release where no changes or artifacts are pushed, defaults to true."
+        required: true
+        type: boolean
+        default: true
+defaults:
+  run:
+    shell: bash
+
+env:
+#  RELEASE_BRANCH: ${{ inputs.releaseBranch != '' && inputs.releaseBranch || format('release-{0}', inputs.releaseVersion) }}
+  RELEASE_VERSION: ${{ inputs.RELEASE_VERSION }}
+  IS_DRY_RUN: ${{ inputs.IS_DRY_RUN }}
+  DEVELOPMENT_VERSION: ${{ inputs.DEVELOPMENT_VERSION }}
+  PUSH_CHANGES: ${{ inputs.IS_DRY_RUN == false }}
+  GH_TOKEN: ${{ github.token }}
+
+jobs:
+  release:
+    name: Maven Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Output Inputs
+        run: echo "${{ toJSON(github.event.inputs) }}"
+
+      # This step generates a GitHub App token to be used in Git operations as a workaround  for
+      # the known GitHub issue described in https://github.com/camunda/camunda/issues/28522
+      - name: Generate GitHub token
+        id: github-token
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
+        with:
+          github-app-id-vault-key: GITHUB_APP_ID
+          github-app-id-vault-path: secret/data/products/cambpm/ci/github-workflow
+          github-app-private-key-vault-key: GITHUB_APP_PRIVATE_KEY
+          github-app-private-key-vault-path: secret/data/products/cambpm/ci/github-workflow
+          vault-auth-method: approle
+          vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID}}
+          vault-url: ${{ secrets.VAULT_ADDR }}
+
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          ref: 4990-add-release-workflow
+#          TODO adjust branch after testing
+#          ref: ${{ RELEASE_BRANCH }}
+          # Overriding the default GITHUB_TOKEN with a GitHub App token in order to workaround
+          # the known GitHub issue described in https://github.com/camunda/camunda/issues/28522
+          # NOTES:
+          # - This token will be used for all git operations in this job
+          # - This token expires after 1 hour (https://github.com/actions/create-github-app-token?tab=readme-ov-file#create-github-app-token)
+          token: ${{ steps.github-token.outputs.token }}
+
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v3.3.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE;
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC;
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_GPG_SIGNING_KEY_PUB;
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_DEPLOYMENT_USR;
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_DEPLOYMENT_PSW;
+
+      - name: Git User Setup
+        run: |
+          git config --global user.email "github-actions[release]"
+          git config --global user.name "github-actions[release]@users.noreply.github.com"
+
+      - name: Install Maven Central GPG Key
+        # setup-maven supports this as well but needs the key in the armor ascii format,
+        # while we only have it plain bas64 encoded
+        # see https://github.com/actions/setup-java/issues/100#issuecomment-742679976
+        run: |
+          echo -n "${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC }}" \
+            | base64 --decode \
+            | gpg -q --allow-secret-key-import --import --no-tty --batch --yes
+          echo -n "${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PUB }}" \
+            | base64 --decode \
+            | gpg -q --import --no-tty --batch --yes
+          
+      - name: Setup Build Tooling
+        uses: ./.github/actions/setup-maven
+        with:
+          secrets: ${{ toJSON(secrets) }}
+
+      # TODO camunda/camunda-bpm-platform/issues/4993
+      # Temp build migrator branch in platform
+      - name: Clone Platform
+        run: |
+          cd ../
+          git clone https://github.com/camunda/camunda-bpm-platform.git
+
+      - name: Build feature branch
+        run: |
+          cd ../camunda-bpm-platform/engine
+          git checkout poc-data-migrator
+          mvn clean install -DskipTests --batch-mode
+      # End of Temp build migrator branch in platform
+      
+      - name: Maven Prepare Release
+        id: maven-prepare-release
+        run: |
+          # Preparing the maven release
+          # https://maven.apache.org/maven-release/maven-release-plugin/prepare-mojo.html
+          # https://maven.apache.org/maven-release/maven-release-plugin/usage/prepare-release.html
+          #
+          # -DpreparationGoals
+          #   Goals to run as part of the preparation step, after transformation but before committing. Space delimited.
+          #   Default is 'clean verify'; We want to skip all the checks and packaging (as it will be done again later) so we set it to empty
+          #
+          # -Darguments
+          #   Additional arguments to pass to the Maven executions, separated by spaces.
+          #   Per default it is not required, but the release plugin is configured in the camunda release plugin (and this property is used)
+          #   This is the reason why we have to set it at least as empty string.
+          mvn release:prepare -B \
+            -Dresume=false \
+            -Dtag="0.1.0-alpha1-rc1" \
+            -DreleaseVersion="0.1.0-alpha1-rc1" \
+            -DdevelopmentVersion="0.1.0-SNAPSHOT" \
+            -DpushChanges=false \
+            -DremoteTagging=false \
+            -DignoreSnapshots=true \
+            -Darguments='-DskipTests=true -Dgpg.passphrase="${{ steps.secrets.outputs
+          .MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}'
+
+      - name: Collect Release artifacts
+        id: release-artifacts
+        run: |
+          ARTIFACT_DIR=$(mktemp -d)
+          cp assembly/target/c7-data-migrator-assembly-0.1.0-alpha1-rc1.tar.gz "${ARTIFACT_DIR}/"
+          cp assembly/target/c7-data-migrator-assembly-0.1.0-alpha1-rc1.zip "${ARTIFACT_DIR}/"
+          echo "dir=${ARTIFACT_DIR}" >> $GITHUB_OUTPUT
+          #          TODO adjust after testing
+          #          cp assembly/target/c7-data-migrator-assembly-${RELEASE_VERSION}.tar.gz "${ARTIFACT_DIR}/"
+          #          cp assembly/target/c7-data-migrator-assembly-${RELEASE_VERSION}.zip "${ARTIFACT_DIR}/"
+          
+      - name: Upload Release Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-artifacts-0.1.0-alpha1-rc1 # TODO adjust after testing  name: release-artifacts-${{ inputs.releaseVersion }}
+          path: ${{ steps.release-artifacts.outputs.dir }}
+          retention-days: 5 # TODO clarify retention policy
+
+#          TODO undo changes after testing
+#          mvn release:prepare -B \
+#            -Dresume=false \
+#            -Dtag=${RELEASE_VERSION} \
+#            -DreleaseVersion=${RELEASE_VERSION} \
+#            -DdevelopmentVersion=${DEVELOPMENT_VERSION} \
+#            -DpushChanges=${PUSH_CHANGES} \
+#            -DremoteTagging=${PUSH_CHANGES} \
+#            -DignoreSnapshots=true \
+#            -DpreparationGoals="" \
+#            -Darguments='-Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}'
+
+#      - name: Maven Perform Release
+#        id: maven-perform-release
+#        env:
+#          SKIP_REPO_DEPLOY: ${{ IS_DRY_RUN }}
+#        run: |
+#          # Perform a maven release
+#          # https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html
+#          # https://maven.apache.org/maven-release/maven-release-plugin/usage/perform-release.html
+#
+#          mvn release:perform -B \
+#            -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}" \
+#            -DlocalCheckout=${{ IS_DRY_RUN }} \
+#            -Darguments='-DskipTests=true -Dskip.central.release=${SKIP_REPO_DEPLOY} -Dskip.camunda.release=${SKIP_REPO_DEPLOY} -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}"

--- a/pom.xml
+++ b/pom.xml
@@ -33,13 +33,9 @@
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-<!--    Using C8 repos for now -->
-<!--    <nexus.snapshot.repository>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/</nexus.snapshot.repository>-->
-<!--    <nexus.release.repository>https://artifacts.camunda.com/artifactory/zeebe-io/</nexus.release.repository>-->
-<!--    <nexus.sonatype.url>-->
-   <nexus.snapshot.repository>removedForTesting</nexus.snapshot.repository>
-    <nexus.release.repository>removedForTesting</nexus.release.repository>
-    <nexus.sonatype.url>removedForTesting</nexus.sonatype.url>
+    <nexus.snapshot.repository>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/</nexus.snapshot.repository>
+    <nexus.release.repository>https://artifacts.camunda.com/artifactory/zeebe-io/</nexus.release.repository>
+    <nexus.sonatype.url>https://s01.oss.sonatype.org</nexus.sonatype.url>
   </properties>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -3,6 +3,14 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.camunda</groupId>
+    <artifactId>camunda-release-parent</artifactId>
+    <version>3.9.1</version>
+    <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
+    <relativePath />
+  </parent>
+
   <groupId>io.camunda</groupId>
   <artifactId>c7-data-migrator-root</artifactId>
   <version>0.0.1-SNAPSHOT</version>
@@ -18,11 +26,20 @@
     <version.camunda-7>7.24.0-SNAPSHOT</version.camunda-7>
     <version.camunda-8>8.8.0-SNAPSHOT</version.camunda-8>
     <version.spring-boot>3.4.4</version.spring-boot>
+    <version.java>21</version.java>
 
     <url.source>jdbc:h2:~/Downloads/c8_rdbms-source.db;TRACE_LEVEL_FILE=0;DB_CLOSE_ON_EXIT=FALSE</url.source>
     <url.target>jdbc:h2:~/Downloads/c8_rdbms-target.db;TRACE_LEVEL_FILE=0;DB_CLOSE_ON_EXIT=FALSE</url.target>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+<!--    Using C8 repos for now -->
+<!--    <nexus.snapshot.repository>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/</nexus.snapshot.repository>-->
+<!--    <nexus.release.repository>https://artifacts.camunda.com/artifactory/zeebe-io/</nexus.release.repository>-->
+<!--    <nexus.sonatype.url>-->
+   <nexus.snapshot.repository>removedForTesting</nexus.snapshot.repository>
+    <nexus.release.repository>removedForTesting</nexus.release.repository>
+    <nexus.sonatype.url>removedForTesting</nexus.sonatype.url>
   </properties>
 
   <modules>
@@ -32,6 +49,14 @@
     <module>distro</module>
     <module>assembly</module>
   </modules>
+
+  <scm>
+    <connection>scm:git:https://${env.GITHUB_TOKEN_USR}:${env.GITHUB_TOKEN_PSW}@github.com/camunda/c7-data-migrator
+      .git</connection>
+    <developerConnection>scm:git:https://${env.GITHUB_TOKEN_USR}:${env.GITHUB_TOKEN_PSW}@github.com/camunda/c7-data-migrator.git</developerConnection>
+    <tag>HEAD</tag>
+    <url>https://github.com/camunda/c7-data-migrator</url>
+  </scm>
 
   <repositories>
     <repository>
@@ -86,6 +111,4 @@
       </plugin>
     </plugins>
   </build>
-
-
 </project>


### PR DESCRIPTION
related to [#4990](https://github.com/camunda/camunda-bpm-platform/issues/4990)

- builds jar, zip and tar.gz distros
- attaches a zip to the workflow run with distros (zip and tar)
- artifact upload tested in [this run](https://github.com/camunda/c7-data-migrator/actions/runs/14968975968?pr=13)
- release prepare step tested in previous runs, relase commits reverted after testing (and tags deleted)

For reviewer:
I left two commits so you can double check the hardcoded version vs. the one with the input param substitutions.
Please pay particular attention to how workflow input params are used, looking out for typos and such since this is the part that is not yet tested (I removed the pull_request trigger after testing, and we can only test the workflow trigger once this action is merged to main)