### PR TITLE
chore(release): add maven config

### DIFF
--- a/.github/actions/setup-maven/action.yml
+++ b/.github/actions/setup-maven/action.yml
@@ -74,7 +74,7 @@ runs:
           "id": "camunda-nexus",
           "name": "Camunda Nexus",
           "url": "https://repository.nexus.camunda.cloud/content/groups/internal/",
-          "mirrorOf": "zeebe,zeebe-snapshots"
+          "mirrorOf": "zeebe,zeebe-snapshots,camunda-bpm-snapshots"
         }]
       CAMUNDA_NEXUS_MAVEN_SERVER: >-
         [{

--- a/.github/actions/setup-maven/action.yml
+++ b/.github/actions/setup-maven/action.yml
@@ -74,7 +74,7 @@ runs:
           "id": "camunda-nexus",
           "name": "Camunda Nexus",
           "url": "https://repository.nexus.camunda.cloud/content/groups/internal/",
-          "mirrorOf": "zeebe,zeebe-snapshots,camunda-bpm-snapshots,camunda-bpm-ee-snapshots"
+          "mirrorOf": "*"
         }]
       CAMUNDA_NEXUS_MAVEN_SERVER: >-
         [{

--- a/.github/actions/setup-maven/action.yml
+++ b/.github/actions/setup-maven/action.yml
@@ -74,7 +74,7 @@ runs:
           "id": "camunda-nexus",
           "name": "Camunda Nexus",
           "url": "https://repository.nexus.camunda.cloud/content/groups/internal/",
-          "mirrorOf": "zeebe,zeebe-snapshots,camunda-bpm-snapshots"
+          "mirrorOf": "zeebe,zeebe-snapshots,camunda-bpm-snapshots,camunda-bpm-ee-snapshots"
         }]
       CAMUNDA_NEXUS_MAVEN_SERVER: >-
         [{

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.1.0 https://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId/>
+    <artifactId/>
+    <version/>
+  </extension>
+</extensions>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,8 +1,3 @@
 <extensions xmlns="http://maven.apache.org/EXTENSIONS/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.1.0 https://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
-  <extension>
-    <groupId/>
-    <artifactId/>
-    <version/>
-  </extension>
 </extensions>

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,9 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens=java.base/java.util=ALL-UNNAMED
+--add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+--add-opens=java.base/java.text=ALL-UNNAMED
+--add-opens=java.desktop/java.awt.font=ALL-UNNAMED

--- a/examples/generate-runtime/pom.xml
+++ b/examples/generate-runtime/pom.xml
@@ -43,7 +43,7 @@
 
     <dependency>
       <groupId>org.camunda.bpm.springboot</groupId>
-      <artifactId>camunda-bpm-spring-boot-starter-webapp-ee</artifactId>
+      <artifactId>camunda-bpm-spring-boot-starter-webapp</artifactId>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,11 @@
       <snapshots />
       <url>https://artifacts.camunda.com/artifactory/camunda-bpm-snapshots/</url>
     </repository>
+    <repository>
+      <id>camunda-bpm-ee-snapshots</id>
+      <snapshots />
+      <url>https://artifacts.camunda.com/artifactory/camunda-bpm-ee-snapshots/</url>
+    </repository>
   </repositories>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -93,10 +93,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${plugin.version.compiler}</version>
-          <configuration>
-            <parameters>true</parameters>
-            <release>${version.java}</release>
-          </configuration>
         </plugin>
         <plugin>
           <groupId>org.sonatype.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -61,11 +61,6 @@
       <snapshots />
       <url>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/</url>
     </repository>
-    <repository>
-      <id>c7-snapshots</id>
-      <snapshots />
-      <url>https://artifacts.camunda.com/artifactory/camunda-bpm-snapshots/</url>
-    </repository>
   </repositories>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -57,9 +57,14 @@
 
   <repositories>
     <repository>
-      <id>c8-snapshots</id>
+      <id>zeebe-snapshots</id>
       <snapshots />
       <url>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/</url>
+    </repository>
+    <repository>
+      <id>camunda-bpm-snapshots</id>
+      <snapshots />
+      <url>https://artifacts.camunda.com/artifactory/camunda-bpm-snapshots/</url>
     </repository>
   </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,8 @@
     <version.camunda-8>8.8.0-SNAPSHOT</version.camunda-8>
     <version.spring-boot>3.4.4</version.spring-boot>
     <version.java>21</version.java>
+    <plugin.version.compiler>3.14.0</plugin.version.compiler>
+    <plugin.version.nexus-staging>1.6.14</plugin.version.nexus-staging>
 
     <url.source>jdbc:h2:~/Downloads/c8_rdbms-source.db;TRACE_LEVEL_FILE=0;DB_CLOSE_ON_EXIT=FALSE</url.source>
     <url.target>jdbc:h2:~/Downloads/c8_rdbms-target.db;TRACE_LEVEL_FILE=0;DB_CLOSE_ON_EXIT=FALSE</url.target>
@@ -84,6 +86,24 @@
                 </includes>
               </licenseSet>
             </licenseSets>
+          </configuration>
+        </plugin>
+        <!-- MAVEN COMPILER -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>${plugin.version.compiler}</version>
+          <configuration>
+            <parameters>true</parameters>
+            <release>${version.java}</release>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.sonatype.plugins</groupId>
+          <artifactId>nexus-staging-maven-plugin</artifactId>
+          <version>${plugin.version.nexus-staging}</version>
+          <configuration>
+            <stagingProgressTimeoutMinutes>40</stagingProgressTimeoutMinutes>
           </configuration>
         </plugin>
       </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -55,9 +55,14 @@
 
   <repositories>
     <repository>
-      <id>snapshots</id>
+      <id>c8-snapshots</id>
       <snapshots />
       <url>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/</url>
+    </repository>
+    <repository>
+      <id>c7-snapshots</id>
+      <snapshots />
+      <url>https://artifacts.camunda.com/artifactory/camunda-bpm-snapshots/</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
https://github.com/camunda/camunda-bpm-platform/issues/4990

Addressing issues in https://github.com/camunda/c7-data-migrator/actions/runs/14974131069/job/42061972951

<details><summary>Details</summary>

```
[INFO] --- nexus-staging-maven-plugin:1.6.8:deploy (default-deploy) @ c7-data-migrator-root ---
    [INFO] Performing deferred deploys (gathering into "/home/runner/work/c7-data-migrator/c7-data-migrator/target/checkout/target/nexus-staging/deferred")...
    [INFO] Installing /home/runner/work/c7-data-migrator/c7-data-migrator/target/checkout/pom.xml to /home/runner/work/c7-data-migrator/c7-data-migrator/target/checkout/target/nexus-staging/deferred/io/camunda/c7-data-migrator-root/0.1.0-alpha1-rc2/c7-data-migrator-root-0.1.0-alpha1-rc2.pom
    [INFO] Installing /home/runner/work/c7-data-migrator/c7-data-migrator/target/checkout/target/c7-data-migrator-root-0.1.0-alpha1-rc2.pom.asc to /home/runner/work/c7-data-migrator/c7-data-migrator/target/checkout/target/nexus-staging/deferred/io/camunda/c7-data-migrator-root/0.1.0-alpha1-rc2/c7-data-migrator-root-0.1.0-alpha1-rc2.pom.asc
    [INFO] Execution skipped to the last project...
    [INFO] 
    [INFO] --- nexus-staging-maven-plugin:1.6.8:deploy (central-deploy) @ c7-data-migrator-root ---
    [INFO] Performing local staging (local stagingDirectory="/home/runner/work/c7-data-migrator/c7-data-migrator/target/checkout/target/nexus-staging/staging")...
    [INFO]  + Using server credentials "central" from Maven settings.
    [INFO] ------------------------------------------------------------------------
    [INFO] Reactor Summary for C7 Data Migrator - Root 0.1.0-alpha1-rc2:
    [INFO] 
    [INFO] C7 Data Migrator - Root ............................ FAILURE [  2.001 s]
    [INFO] C7 Data Migrator – Core ............................ SKIPPED
    [INFO] C7 Data Migrator - Examples ........................ SKIPPED
    [INFO] C7 Data Migrator - Examples - Migrate Runtime ...... SKIPPED
    [INFO] C7 Data Migrator - Examples - Generate Runtime ..... SKIPPED
    [INFO] C7 Data Migrator - Examples - Migrate History ...... SKIPPED
    [INFO] C7 Data Migrator - QA .............................. SKIPPED
    [INFO] C7 Data Migrator - Distro .......................... SKIPPED
    [INFO] C7 Data Migrator - Assembly ........................ SKIPPED
    [INFO] ------------------------------------------------------------------------
    [INFO] BUILD FAILURE
    [INFO] ------------------------------------------------------------------------
    [INFO] Total time:  2.648 s
    [INFO] Finished at: 2025-05-12T13:56:54Z
    [INFO] ------------------------------------------------------------------------
Error: ROR] Failed to execute goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.8:deploy (central-deploy) on project c7-data-migrator-root: Execution central-deploy of goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.8:deploy failed: An API incompatibility was encountered while executing org.sonatype.plugins:nexus-staging-maven-plugin:1.6.8:deploy: java.lang.ExceptionInInitializerError: null
Error: ROR] -----------------------------------------------------
Error: ROR] realm =    extension>org.sonatype.plugins:nexus-staging-maven-plugin:1.6.8
Error: ROR] strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
Error: ROR] urls[0] = file:/home/runner/.m2/repository/org/sonatype/plugins/nexus-staging-maven-plugin/1.6.8/nexus-staging-maven-plugin-1.6.8.jar
Error: ROR] urls[1] = file:/home/runner/.m2/repository/org/sonatype/nexus/maven/nexus-common/1.6.8/nexus-common-1.6.8.jar
Error: ROR] urls[2] = file:/home/runner/.m2/repository/org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.jar
Error: ROR] urls[3] = file:/home/runner/.m2/repository/org/sonatype/plexus/plexus-cipher/1.7/plexus-cipher-1.7.jar
Error: ROR] urls[4] = file:/home/runner/.m2/repository/com/google/guava/guava/14.0.1/guava-14.0.1.jar
Error: ROR] urls[5] = file:/home/runner/.m2/repository/org/sonatype/nexus/nexus-client-core/2.14.3-02/nexus-client-core-2.14.3-02.jar
Error: ROR] urls[6] = file:/home/runner/.m2/repository/org/sonatype/nexus/plugins/nexus-restlet1x-model/2.14.3-02/nexus-restlet1x-model-2.14.3-02.jar
Error: ROR] urls[7] = file:/home/runner/.m2/repository/com/google/code/findbugs/jsr305/2.0.1/jsr305-2.0.1.jar
Error: ROR] urls[8] = file:/home/runner/.m2/repository/com/intellij/annotations/9.0.4/annotations-9.0.4.jar
Error: ROR] urls[9] = file:/home/runner/.m2/repository/commons-io/commons-io/2.4/commons-io-2.4.jar
Error: ROR] urls[10] = file:/home/runner/.m2/repository/com/thoughtworks/xstream/xstream/1.4.7/xstream-1.4.7.jar
Error: ROR] urls[11] = file:/home/runner/.m2/repository/xmlpull/xmlpull/1.1.3.1/xmlpull-1.1.3.1.jar
Error: ROR] urls[12] = file:/home/runner/.m2/repository/xpp3/xpp3_min/1.1.4c/xpp3_min-1.1.4c.jar
Error: ROR] urls[13] = file:/home/runner/.m2/repository/joda-time/joda-time/2.2/joda-time-2.2.jar
Error: ROR] urls[14] = file:/home/runner/.m2/repository/commons-lang/commons-lang/2.6/commons-lang-2.6.jar
Error: ROR] urls[15] = file:/home/runner/.m2/repository/commons-beanutils/commons-beanutils-core/1.8.3/commons-beanutils-core-1.8.3.jar
Error: ROR] urls[16] = file:/home/runner/.m2/repository/org/sonatype/sisu/siesta/siesta-client/1.7/siesta-client-1.7.jar
Error: ROR] urls[17] = file:/home/runner/.m2/repository/org/sonatype/sisu/siesta/siesta-common/1.7/siesta-common-1.7.jar
Error: ROR] urls[18] = file:/home/runner/.m2/repository/javax/ws/rs/jsr311-api/1.1.1/jsr311-api-1.1.1.jar
Error: ROR] urls[19] = file:/home/runner/.m2/repository/com/sun/jersey/jersey-core/1.17.1/jersey-core-1.17.1.jar
Error: ROR] urls[20] = file:/home/runner/.m2/repository/javax/validation/validation-api/1.1.0.Final/validation-api-1.1.0.Final.jar
Error: ROR] urls[21] = file:/home/runner/.m2/repository/com/sun/jersey/jersey-client/1.17.1/jersey-client-1.17.1.jar
Error: ROR] urls[22] = file:/home/runner/.m2/repository/com/sun/jersey/contribs/jersey-apache-client4/1.17.1/jersey-apache-client4-1.17.1.jar
Error: ROR] urls[23] = file:/home/runner/.m2/repository/org/sonatype/sisu/siesta/siesta-jackson/1.7/siesta-jackson-1.7.jar
Error: ROR] urls[24] = file:/home/runner/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.3.1/jackson-annotations-2.3.1.jar
Error: ROR] urls[25] = file:/home/runner/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.3.1/jackson-core-2.3.1.jar
Error: ROR] urls[26] = file:/home/runner/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.3.1/jackson-databind-2.3.1.jar
Error: ROR] urls[27] = file:/home/runner/.m2/repository/com/fasterxml/jackson/jaxrs/jackson-jaxrs-json-provider/2.3.1/jackson-jaxrs-json-provider-2.3.1.jar
Error: ROR] urls[28] = file:/home/runner/.m2/repository/com/fasterxml/jackson/jaxrs/jackson-jaxrs-base/2.3.1/jackson-jaxrs-base-2.3.1.jar
Error: ROR] urls[29] = file:/home/runner/.m2/repository/com/fasterxml/jackson/module/jackson-module-jaxb-annotations/2.3.1/jackson-module-jaxb-annotations-2.3.1.jar
Error: ROR] urls[30] = file:/home/runner/.m2/repository/org/apache/httpcomponents/httpclient/4.3.5/httpclient-4.3.5.jar
Error: ROR] urls[31] = file:/home/runner/.m2/repository/commons-codec/commons-codec/1.6/commons-codec-1.6.jar
Error: ROR] urls[32] = file:/home/runner/.m2/repository/org/apache/httpcomponents/httpcore/4.3.2/httpcore-4.3.2.jar
Error: ROR] urls[33] = file:/home/runner/.m2/repository/org/slf4j/jcl-over-slf4j/1.7.7/jcl-over-slf4j-1.7.7.jar
Error: ROR] urls[34] = file:/home/runner/.m2/repository/org/sonatype/spice/zapper/spice-zapper/1.3/spice-zapper-1.3.jar
Error: ROR] urls[35] = file:/home/runner/.m2/repository/org/fusesource/hawtbuf/hawtbuf-proto/1.9/hawtbuf-proto-1.9.jar
Error: ROR] urls[36] = file:/home/runner/.m2/repository/org/fusesource/hawtbuf/hawtbuf/1.9/hawtbuf-1.9.jar
Error: ROR] urls[37] = file:/home/runner/.m2/repository/org/codehaus/plexus/plexus-utils/3.0.8/plexus-utils-3.0.8.jar
Error: ROR] urls[38] = file:/home/runner/.m2/repository/org/codehaus/plexus/plexus-interpolation/1.15/plexus-interpolation-1.15.jar
Error: ROR] urls[39] = file:/home/runner/.m2/repository/ch/qos/logback/logback-core/1.1.2/logback-core-1.1.2.jar
Error: ROR] urls[40] = file:/home/runner/.m2/repository/ch/qos/logback/logback-classic/1.1.2/logback-classic-1.1.2.jar
Error: ROR] Number of foreign imports: 1
Error: ROR] import: Entry[import  from realm ClassRealm[maven.api, parent: null]]
Error: ROR] 
Error: ROR] -----------------------------------------------------: Unable to make field private final java.util.Comparator java.util.TreeMap.comparator accessible: module java.base does not "opens java.util" to unnamed module @29c5ee1d
Error: ROR] -> [Help 1]
Error: ROR] 
Error: ROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
Error: ROR] Re-run Maven using the -X switch to enable full debug logging.
Error: ROR] 
Error: ROR] For more information about the errors and possible solutions, please read the following articles:
Error: ROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginContainerException
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for C7 Data Migrator - Root 0.1.0-SNAPSHOT:
[INFO] 
[INFO] C7 Data Migrator - Root ............................ FAILURE [  4.325 s]
[INFO] C7 Data Migrator – Core ............................ SKIPPED
[INFO] C7 Data Migrator - Examples ........................ SKIPPED
[INFO] C7 Data Migrator - Examples - Migrate Runtime ...... SKIPPED
[INFO] C7 Data Migrator - Examples - Generate Runtime ..... SKIPPED
[INFO] C7 Data Migrator - Examples - Migrate History ...... SKIPPED
[INFO] C7 Data Migrator - QA .............................. SKIPPED
[INFO] C7 Data Migrator - Distro .......................... SKIPPED
[INFO] C7 Data Migrator - Assembly ........................ SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  5.080 s
[INFO] Finished at: [202](https://github.com/camunda/c7-data-migrator/actions/runs/14974131069/job/42061972951#step:12:203)5-05-12T13:56:54Z
[INFO] ------------------------------------------------------------------------
Error:  Failed to execute goal org.apache.maven.plugins:maven-release-plugin:2.5.3:perform (default-cli) on project c7-data-migrator-root: Maven execution failed, exit code: '1' -> [Help 1]
```

</details> 