### PR TITLE
chore(distro): disable history migration temporarily

### DIFF
--- a/distro/src/main/java/io/camunda/migrator/app/MigratorApp.java
+++ b/distro/src/main/java/io/camunda/migrator/app/MigratorApp.java
@@ -68,9 +68,8 @@ public class MigratorApp {
     historyMigrator.migrate();
   }
 
-  private static boolean shouldRunFullMigration(ApplicationArguments appArgs) {
-    // Return true either when both --runtime and --history are present or when neither is present
-    return (appArgs.containsOption(RUN_RUNTIME_MIGRATION) && appArgs.containsOption(RUN_HISTORY_MIGRATION)) ||
-        (!appArgs.containsOption(RUN_RUNTIME_MIGRATION) && !appArgs.containsOption(RUN_HISTORY_MIGRATION));
+  protected static boolean shouldRunFullMigration(ApplicationArguments appArgs) {
+    // Return true either when both --runtime and --history are present
+    return appArgs.containsOption(RUN_RUNTIME_MIGRATION) && appArgs.containsOption(RUN_HISTORY_MIGRATION);
   }
 }


### PR DESCRIPTION
* Let's disable history migration when not providing any flags temporarily since we don't focus on history migration for now, and the getting started experience is degraded when seeing errors coming from the history migrator.
* We will revert this behavior once work on the history migrator starts.

related to camunda/camunda-bpm-platform#5189