### PR TITLE
chore(doc): document boundary event limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@
 - Message events:
   - only message catch and throw events are supported for migration
   - depending on your implementation, you may need to add [a correlation variable](https://docs.camunda.io/docs/components/modeler/bpmn/message-events/#messages) to the instance pre migration
-- Boundary events:
-  - currently not supported
+- Triggered Boundary events:
+  - C7 boundary events do not have a true wait state
+  - if the process to be migrated is currently at a triggered boundary event there may be a job associated with this event waiting for execution/being executed. At this point in time, the token is considered to be at the flow element where the job is created (usually the first element of the handler flow, or technically at the point after the boundary event if asyncAfter is used). Migration will occur accordingly to the equivalent element in C8. If this element eg requires data that is created with the associated boundary event job, this may be missing from the instance. We recommend to finish boundary event executions prior to migrating.
+- There are elements that are supported in C7 but not supported in C8. Please refer to the [documentation](https://docs.camunda.io/docs/next/components/modeler/bpmn/bpmn-coverage/) for more details on element support in C8 and adjust your models accordingly before migration.
 
 ## Development Setup
 1. Prerequisites: Use Java 21

--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@
   - only message catch and throw events are supported for migration
   - depending on your implementation, you may need to add [a correlation variable](https://docs.camunda.io/docs/components/modeler/bpmn/message-events/#messages) to the instance pre migration
 - Triggered Boundary events:
-  - C7 boundary events do not have a true wait state
-  - if the process to be migrated is currently at a triggered boundary event there may be a job associated with this event waiting for execution/being executed. At this point in time, the token is considered to be at the flow element where the job is created (usually the first element of the handler flow, or technically at the point after the boundary event if asyncAfter is used). Migration will occur accordingly to the equivalent element in C8. If this element eg requires data that is created with the associated boundary event job, this may be missing from the instance. We recommend to finish boundary event executions prior to migrating.
+  - C7 boundary events do not have a natural wait state
+  - If the process instance to be migrated is currently at a triggered boundary event in Camunda 7, there may still be a job associated with that event, either waiting to be executed or currently running. In this state, the token is considered to be at the element where the job is created: typically the first activity of the boundary event’s handler flow, or technically the point after the boundary event if asyncAfter is used.
+  - During migration to Camunda 8, the token will be mapped to the corresponding target element. However, if that element expects input data that is normally produced by the boundary event’s job (e.g. setting variables), this data may be missing in the migrated instance.
+  - Recommendation: To ensure a consistent migration, allow boundary event executions to complete before initiating the migration.
 - There are elements that are supported in C7 but not supported in C8. Please refer to the [documentation](https://docs.camunda.io/docs/next/components/modeler/bpmn/bpmn-coverage/) for more details on element support in C8 and adjust your models accordingly before migration.
 
 ## Development Setup


### PR DESCRIPTION
related to [#5172](https://github.com/camunda/camunda-bpm-platform/issues/5172)

Documents boundary event limitations
Also adds a general note about elements that exist in C7 but not in C8