### PR TITLE
chore(IT): tests for unsupported start events

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@
 - Message events:
   - only message catch and throw events are supported for migration
   - depending on your implementation, you may need to add [a correlation variable](https://docs.camunda.io/docs/components/modeler/bpmn/message-events/#messages) to the instance pre migration
+- Message and Signal start events:
+  - If your process starts with a message/signal start event, no token exists until the message/signal is received and hence no migration is possible until that moment
+  - Once the message/signal is received, the token is created and moved down the execution flow and may be waiting at a migratable element inside the process. However, due to how the migration logic is implemented, at the moment the data migrator only supports processes that start with a normal start event. This is to be addressed with [this ticket](https://github.com/camunda/camunda-bpm-platform/issues/5195)
 - Triggered Boundary events:
   - C7 boundary events do not have a natural wait state
   - If the process instance to be migrated is currently at a triggered boundary event in Camunda 7, there may still be a job associated with that event, either waiting to be executed or currently running. In this state, the token is considered to be at the element where the job is created: typically the first activity of the boundary event’s handler flow, or technically the point after the boundary event if asyncAfter is used.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@
    <zeebe:ioMapping>
      <zeebe:input source="=legacyId" target="legacyId" />
    </zeebe:ioMapping>
+- Multi-instance:
+  - Processes with active multi-instance elements can currently not be migrated. We recommend to finish the execution of any multi-instance elements prior to migration.
 
 #### Configuration
 

--- a/qa/src/test/java/io/camunda/migrator/qa/UnsupportedMigrationTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/UnsupportedMigrationTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+package io.camunda.migrator.qa;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.migrator.MigratorException;
+import org.junit.jupiter.api.Test;
+
+public class UnsupportedMigrationTest extends RuntimeMigrationAbstractTest {
+
+  @Test
+  public void migrateProcessWithUnsupportedStartEvent() {
+    // given
+    deployProcessInC7AndC8("messageStartEventProcess.bpmn");
+    runtimeService.correlateMessage("msgRef");
+
+    // when/then
+    assertThatThrownBy(() -> runtimeMigrator.migrate()).isInstanceOf(MigratorException.class)
+        .hasMessageContaining(
+            "Error occurred: shutting down Data Migrator gracefully.")
+        .hasRootCauseMessage("FAILED_PRECONDITION: Command 'CREATE' rejected with code 'INVALID_STATE': Expected to "
+            + "create instance of process with none start event, but there is no such event");
+  }
+}

--- a/qa/src/test/java/io/camunda/migrator/qa/element/AbstractElementMigrationTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/element/AbstractElementMigrationTest.java
@@ -6,13 +6,14 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-package io.camunda.migrator.qa;
+package io.camunda.migrator.qa.element;
 
 import static io.camunda.migrator.qa.MigrationTestConstants.LEGACY_ID_VAR_NAME;
 import static io.camunda.process.test.api.CamundaAssert.assertThat;
 import static io.camunda.process.test.api.assertions.ElementSelectors.byId;
 import static io.camunda.process.test.api.assertions.ProcessInstanceSelectors.byProcessId;
 
+import io.camunda.migrator.qa.RuntimeMigrationAbstractTest;
 import java.util.stream.Stream;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.junit.jupiter.api.TestInstance;

--- a/qa/src/test/java/io/camunda/migrator/qa/element/GatewayMigrationTests.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/element/GatewayMigrationTests.java
@@ -5,13 +5,14 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.migrator.qa;
+package io.camunda.migrator.qa.element;
 
 import static io.camunda.migrator.qa.MigrationTestConstants.LEGACY_ID_VAR_NAME;
 import static io.camunda.process.test.api.CamundaAssert.assertThat;
 import static io.camunda.process.test.api.assertions.ElementSelectors.byId;
 import static io.camunda.process.test.api.assertions.ProcessInstanceSelectors.byProcessId;
 
+import io.camunda.migrator.qa.RuntimeMigrationAbstractTest;
 import java.util.Map;
 import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.runtime.ProcessInstance;

--- a/qa/src/test/java/io/camunda/migrator/qa/element/MessageEventMigrationTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/element/MessageEventMigrationTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.migrator.qa;
+package io.camunda.migrator.qa.element;
 
 import static io.camunda.migrator.qa.MigrationTestConstants.LEGACY_ID_VAR_NAME;
 import static io.camunda.process.test.api.CamundaAssert.assertThat;

--- a/qa/src/test/java/io/camunda/migrator/qa/element/SignalMigrationTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/element/SignalMigrationTest.java
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-package io.camunda.migrator.qa;
+package io.camunda.migrator.qa.element;
 
 import java.util.stream.Stream;
 import org.junit.jupiter.params.provider.Arguments;

--- a/qa/src/test/java/io/camunda/migrator/qa/element/SubprocessMigrationTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/element/SubprocessMigrationTest.java
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-package io.camunda.migrator.qa;
+package io.camunda.migrator.qa.element;
 
 import static io.camunda.migrator.qa.MigrationTestConstants.LEGACY_ID_VAR_NAME;
 import static io.camunda.process.test.api.CamundaAssert.assertThat;
@@ -14,12 +14,11 @@ import static io.camunda.process.test.api.assertions.ElementSelectors.byId;
 import static io.camunda.process.test.api.assertions.ProcessInstanceSelectors.byProcessId;
 import static io.camunda.process.test.api.assertions.UserTaskSelectors.byTaskName;
 
-import java.util.stream.Stream;
+import io.camunda.migrator.qa.RuntimeMigrationAbstractTest;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.provider.Arguments;
 
-public class SubprocessMigrationTest extends RuntimeMigrationAbstractTest{
+public class SubprocessMigrationTest extends RuntimeMigrationAbstractTest {
 
   @Test
   public void migrateCallActivityAndSubprocess() {

--- a/qa/src/test/java/io/camunda/migrator/qa/element/TaskMigrationTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/element/TaskMigrationTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.migrator.qa;
+package io.camunda.migrator.qa.element;
 
 import static io.camunda.process.test.api.CamundaAssert.assertThat;
 import static io.camunda.process.test.api.assertions.ElementSelectors.byId;

--- a/qa/src/test/java/io/camunda/migrator/qa/element/UnsupportedStartEventMigrationTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/element/UnsupportedStartEventMigrationTest.java
@@ -6,15 +6,17 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-package io.camunda.migrator.qa;
+package io.camunda.migrator.qa.element;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.migrator.MigratorException;
+import io.camunda.migrator.qa.RuntimeMigrationAbstractTest;
 import org.junit.jupiter.api.Test;
 
-public class UnsupportedMigrationTest extends RuntimeMigrationAbstractTest {
+public class UnsupportedStartEventMigrationTest extends RuntimeMigrationAbstractTest {
 
+  // To be addressed with https://github.com/camunda/camunda-bpm-platform/issues/5195
   @Test
   public void migrateProcessWithUnsupportedStartEvent() {
     // given
@@ -22,7 +24,7 @@ public class UnsupportedMigrationTest extends RuntimeMigrationAbstractTest {
     runtimeService.correlateMessage("msgRef");
 
     // when/then
-    assertThatThrownBy(() -> runtimeMigrator.migrate()).isInstanceOf(MigratorException.class)
+    assertThatThrownBy(() -> runtimeMigrator.start()).isInstanceOf(MigratorException.class)
         .hasMessageContaining(
             "Error occurred: shutting down Data Migrator gracefully.")
         .hasRootCauseMessage("FAILED_PRECONDITION: Command 'CREATE' rejected with code 'INVALID_STATE': Expected to "

--- a/qa/src/test/java/io/camunda/migrator/qa/element/UnsupportedStartEventMigrationTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/element/UnsupportedStartEventMigrationTest.java
@@ -26,7 +26,7 @@ public class UnsupportedStartEventMigrationTest extends RuntimeMigrationAbstract
     // when/then
     assertThatThrownBy(() -> runtimeMigrator.start()).isInstanceOf(MigratorException.class)
         .hasMessageContaining(
-            "Error occurred: shutting down Data Migrator gracefully.")
+            "Creating process instance failed for legacyId: ")
         .hasRootCauseMessage("FAILED_PRECONDITION: Command 'CREATE' rejected with code 'INVALID_STATE': Expected to "
             + "create instance of process with none start event, but there is no such event");
   }

--- a/qa/src/test/resources/io/camunda/migrator/bpmn/c7/messageStartEventProcess.bpmn
+++ b/qa/src/test/resources/io/camunda/migrator/bpmn/c7/messageStartEventProcess.bpmn
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1tmeq3c" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.24.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.21.0">
+  <bpmn:process id="MessageStartEventProcessId" name="MessageStartEventProcess" isExecutable="true" camunda:historyTimeToLive="1">
+    <bpmn:sequenceFlow id="Flow_1hpxz6b" sourceRef="MessageStartEventId" targetRef="Activity_088ub3b" />
+    <bpmn:endEvent id="Event_1s06k8s">
+      <bpmn:incoming>Flow_0yxhkfo</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0yxhkfo" sourceRef="Activity_088ub3b" targetRef="Event_1s06k8s" />
+    <bpmn:userTask id="Activity_088ub3b">
+      <bpmn:incoming>Flow_1hpxz6b</bpmn:incoming>
+      <bpmn:outgoing>Flow_0yxhkfo</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:startEvent id="MessageStartEventId" name="MessageStartEvent">
+      <bpmn:outgoing>Flow_1hpxz6b</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1s43wa8" messageRef="Message_3gqstme" />
+    </bpmn:startEvent>
+  </bpmn:process>
+  <bpmn:message id="Message_3gqstme" name="msgRef" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MessageStartEventProcessId">
+      <bpmndi:BPMNShape id="Event_1s06k8s_di" bpmnElement="Event_1s06k8s">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0611i7v_di" bpmnElement="Activity_088ub3b">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_17i782p_di" bpmnElement="MessageStartEventId">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="154" y="142" width="87" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0yxhkfo_di" bpmnElement="Flow_0yxhkfo">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1hpxz6b_di" bpmnElement="Flow_1hpxz6b">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/src/test/resources/io/camunda/migrator/bpmn/c8/messageStartEventProcess.bpmn
+++ b/qa/src/test/resources/io/camunda/migrator/bpmn/c8/messageStartEventProcess.bpmn
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:conversion="http://camunda.org/schema/conversion/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" conversion:converterVersion="0.12.4" exporter="Camunda Modeler" exporterVersion="5.24.0" expressionLanguage="http://www.w3.org/1999/XPath" id="Definitions_1tmeq3c" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0" targetNamespace="http://bpmn.io/schema/bpmn" typeLanguage="http://www.w3.org/2001/XMLSchema">
   <bpmn:process id="MessageStartEventProcessId" isClosed="false" isExecutable="true" name="MessageStartEventProcess" processType="None">
-    <bpmn:extensionElements>
-      <conversion:message severity="INFO">Unused attribute 'historyTimeToLive' on 'process' is removed.</conversion:message>
-    </bpmn:extensionElements>
     <bpmn:sequenceFlow id="Flow_1hpxz6b" sourceRef="MessageStartEventId" targetRef="Activity_088ub3b"/>
     <bpmn:endEvent id="Event_1s06k8s">
       <bpmn:incoming>Flow_0yxhkfo</bpmn:incoming>

--- a/qa/src/test/resources/io/camunda/migrator/bpmn/c8/messageStartEventProcess.bpmn
+++ b/qa/src/test/resources/io/camunda/migrator/bpmn/c8/messageStartEventProcess.bpmn
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?><bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:conversion="http://camunda.org/schema/conversion/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" conversion:converterVersion="0.12.4" exporter="Camunda Modeler" exporterVersion="5.24.0" expressionLanguage="http://www.w3.org/1999/XPath" id="Definitions_1tmeq3c" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0" targetNamespace="http://bpmn.io/schema/bpmn" typeLanguage="http://www.w3.org/2001/XMLSchema">
+  <bpmn:process id="MessageStartEventProcessId" isClosed="false" isExecutable="true" name="MessageStartEventProcess" processType="None">
+    <bpmn:extensionElements>
+      <conversion:message severity="INFO">Unused attribute 'historyTimeToLive' on 'process' is removed.</conversion:message>
+    </bpmn:extensionElements>
+    <bpmn:sequenceFlow id="Flow_1hpxz6b" sourceRef="MessageStartEventId" targetRef="Activity_088ub3b"/>
+    <bpmn:endEvent id="Event_1s06k8s">
+      <bpmn:incoming>Flow_0yxhkfo</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0yxhkfo" sourceRef="Activity_088ub3b" targetRef="Event_1s06k8s"/>
+    <bpmn:userTask completionQuantity="1" id="Activity_088ub3b" implementation="##unspecified" isForCompensation="false" startQuantity="1">
+      <bpmn:extensionElements>
+        <zeebe:userTask/>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1hpxz6b</bpmn:incoming>
+      <bpmn:outgoing>Flow_0yxhkfo</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:startEvent id="MessageStartEventId" isInterrupting="true" name="MessageStartEvent" parallelMultiple="false">
+      <bpmn:extensionElements>
+        <conversion:reference>Message_3gqstme</conversion:reference>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="end" type="migrator" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_1hpxz6b</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1s43wa8" messageRef="Message_3gqstme"/>
+    </bpmn:startEvent>
+  </bpmn:process>
+  <bpmn:message id="Message_3gqstme" name="msgRef">
+    <bpmn:extensionElements>
+      <conversion:message severity="TASK">Please define a correlation key if the message is used in a message catch event.</conversion:message>
+      <conversion:referencedBy>MessageStartEventId</conversion:referencedBy>
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane bpmnElement="MessageStartEventProcessId" id="BPMNPlane_1">
+      <bpmndi:BPMNShape bpmnElement="Event_1s06k8s" id="Event_1s06k8s_di">
+        <dc:Bounds height="36" width="36" x="432" y="99"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_088ub3b" id="Activity_0611i7v_di">
+        <dc:Bounds height="80" width="100" x="270" y="77"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="MessageStartEventId" id="Event_17i782p_di">
+        <dc:Bounds height="36" width="36" x="179" y="99"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="27" width="87" x="154" y="142"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="Flow_0yxhkfo" id="Flow_0yxhkfo_di">
+        <di:waypoint x="370" y="117"/>
+        <di:waypoint x="432" y="117"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="Flow_1hpxz6b" id="Flow_1hpxz6b_di">
+        <di:waypoint x="215" y="117"/>
+        <di:waypoint x="270" y="117"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
related to [#5172](https://github.com/camunda/camunda-bpm-platform/issues/5172)

Adds tests for signal/message start events.
Note conditional and compensation start events are not supported in C8 so they are already documented.
I still need to look into error and escalation  start events and add respective documentation

Error messages in assertions may need adjusted depending on changes from @venetrius logging ticket. Discussed on slack that he will adjust where necessary if he makes relevant changes
