### PR TITLE
chore(github): skip second checkout in dry run

### DIFF
--- a/.github/workflows/release-c7-data-migrator.yml
+++ b/.github/workflows/release-c7-data-migrator.yml
@@ -154,6 +154,8 @@ jobs:
             -Darguments='-DskipTests=true -Dskip.central.release=true -Dskip.camunda.release=${SKIP_REPO_DEPLOY}'
 
       - name: Checkout Code
+        # Tag does not exist if dry run
+        if: ${{ !inputs.IS_DRY_RUN }}
         uses: actions/checkout@v4
         with:
           # Checkout the release tag to perform a second deployment 


### PR DESCRIPTION
camunda/camunda-bpm-platform/issues/5161