### PR TITLE
feat(core): add db support

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>2.3.232</version>
+      <version>${version.h2}</version>
     </dependency>
 
   </dependencies>

--- a/assembly/resources/application.yml
+++ b/assembly/resources/application.yml
@@ -25,7 +25,7 @@ logging:
     root: INFO
     # io.camunda.migrator: INFO
     # io.camunda.migrator.RuntimeMigrator: DEBUG
-    # io.camunda.migrator.history.IdKeyMapper: DEBUG # persistence
+    # io.camunda.migrator.mapper.IdKeyMapper: DEBUG # persistence
     # org.camunda.bpm: INFO  # C7
   file:
     name: logs/c7-data-migrator.log

--- a/core/src/main/java/io/camunda/migrator/HistoryMigrator.java
+++ b/core/src/main/java/io/camunda/migrator/HistoryMigrator.java
@@ -358,7 +358,7 @@ public class HistoryMigrator {
   protected void insertKeyIdMapping(String id, Long key, IdKeyMapper.TYPE type) {
     var idKeyDbModel = new IdKeyDbModel();
     idKeyDbModel.setId(id);
-    idKeyDbModel.setKey(key);
+    idKeyDbModel.setItemKey(key);
     idKeyDbModel.setType(type);
     idKeyMapper.insert(idKeyDbModel);
   }

--- a/core/src/main/java/io/camunda/migrator/HistoryMigrator.java
+++ b/core/src/main/java/io/camunda/migrator/HistoryMigrator.java
@@ -32,7 +32,7 @@ import io.camunda.migrator.converter.ProcessInstanceConverter;
 import io.camunda.migrator.converter.UserTaskConverter;
 import io.camunda.migrator.converter.VariableConverter;
 import io.camunda.migrator.history.IdKeyDbModel;
-import io.camunda.migrator.history.IdKeyMapper;
+import io.camunda.migrator.mapper.IdKeyMapper;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;

--- a/core/src/main/java/io/camunda/migrator/RuntimeMigrator.java
+++ b/core/src/main/java/io/camunda/migrator/RuntimeMigrator.java
@@ -8,13 +8,13 @@
 package io.camunda.migrator;
 
 import static io.camunda.migrator.ExceptionUtils.callApi;
-import static io.camunda.migrator.history.IdKeyMapper.TYPE;
+import static io.camunda.migrator.mapper.IdKeyMapper.TYPE;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ModifyProcessInstanceCommandStep1;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.migrator.history.IdKeyDbModel;
-import io.camunda.migrator.history.IdKeyMapper;
+import io.camunda.migrator.mapper.IdKeyMapper;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.camunda.bpm.engine.RepositoryService;

--- a/core/src/main/java/io/camunda/migrator/RuntimeMigrator.java
+++ b/core/src/main/java/io/camunda/migrator/RuntimeMigrator.java
@@ -131,7 +131,7 @@ public class RuntimeMigrator {
   protected void storeMapping(String legacyProcessInstanceId, Long processInstanceKey) {
     var keyIdDbModel = new IdKeyDbModel();
     keyIdDbModel.setId(legacyProcessInstanceId);
-    keyIdDbModel.setKey(processInstanceKey);
+    keyIdDbModel.setItemKey(processInstanceKey);
     keyIdDbModel.setType(TYPE.RUNTIME_PROCESS_INSTANCE);
 
     if (retryMode) {

--- a/core/src/main/java/io/camunda/migrator/config/MyBatisConfiguration.java
+++ b/core/src/main/java/io/camunda/migrator/config/MyBatisConfiguration.java
@@ -106,8 +106,8 @@ public class MyBatisConfiguration {
     LOGGER.info("Detected databaseId: {}", databaseId);
 
     final Properties properties = new Properties();
-    final var c8File = "db/vendor-properties/" + databaseId + ".properties";
     final var migratorFile = "db/properties/" + databaseId + ".properties";
+    final var c8File = "db/vendor-properties/" + databaseId + ".properties";
     loadPropertiesFile(databaseId, properties, c8File);
     loadPropertiesFile(databaseId, properties, migratorFile);
 

--- a/core/src/main/java/io/camunda/migrator/config/MyBatisConfiguration.java
+++ b/core/src/main/java/io/camunda/migrator/config/MyBatisConfiguration.java
@@ -106,7 +106,15 @@ public class MyBatisConfiguration {
     LOGGER.info("Detected databaseId: {}", databaseId);
 
     final Properties properties = new Properties();
-    final var file = "db/vendor-properties/" + databaseId + ".properties";
+    final var c8File = "db/vendor-properties/" + databaseId + ".properties";
+    final var migratorFile = "db/properties/" + databaseId + ".properties";
+    loadPropertiesFile(databaseId, properties, c8File);
+    loadPropertiesFile(databaseId, properties, migratorFile);
+
+    return new VendorDatabaseProperties(properties);
+  }
+
+  private void loadPropertiesFile(String databaseId, Properties properties, String file) throws IOException {
     try (final var propertiesInputStream = getClass().getClassLoader().getResourceAsStream(file)) {
       if (propertiesInputStream != null) {
         properties.load(propertiesInputStream);
@@ -115,8 +123,6 @@ public class MyBatisConfiguration {
             "No vendor properties found for databaseId " + databaseId);
       }
     }
-
-    return new VendorDatabaseProperties(properties);
   }
 
   @Bean

--- a/core/src/main/java/io/camunda/migrator/config/MyBatisConfiguration.java
+++ b/core/src/main/java/io/camunda/migrator/config/MyBatisConfiguration.java
@@ -33,7 +33,7 @@ import java.util.Map;
 import java.util.Properties;
 import javax.sql.DataSource;
 
-import io.camunda.migrator.history.IdKeyMapper;
+import io.camunda.migrator.mapper.IdKeyMapper;
 import liquibase.integration.spring.MultiTenantSpringLiquibase;
 import liquibase.integration.spring.SpringLiquibase;
 import org.apache.commons.lang3.StringUtils;

--- a/core/src/main/java/io/camunda/migrator/history/IdKeyDbModel.java
+++ b/core/src/main/java/io/camunda/migrator/history/IdKeyDbModel.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.migrator.history;
 
+import io.camunda.migrator.mapper.IdKeyMapper;
 import java.util.Objects;
 
 public class IdKeyDbModel {

--- a/core/src/main/java/io/camunda/migrator/history/IdKeyDbModel.java
+++ b/core/src/main/java/io/camunda/migrator/history/IdKeyDbModel.java
@@ -11,12 +11,12 @@ import java.util.Objects;
 
 public class IdKeyDbModel {
 
-  protected Long key;
+  protected Long itemKey;
   protected String id;
   protected IdKeyMapper.TYPE type;
 
-  public Long key() {
-    return key;
+  public Long itemKey() {
+    return itemKey;
   }
 
   public String id() {
@@ -27,8 +27,8 @@ public class IdKeyDbModel {
     return type;
   }
 
-  public void setKey(Long key) {
-    this.key = key;
+  public void setItemKey(Long itemKey) {
+    this.itemKey = itemKey;
   }
 
   public void setId(String id) {
@@ -46,17 +46,17 @@ public class IdKeyDbModel {
     if (obj == null || obj.getClass() != this.getClass())
       return false;
     var that = (IdKeyDbModel) obj;
-    return Objects.equals(this.key, that.key) && Objects.equals(this.id, that.id) && Objects.equals(this.type, that.type);
+    return Objects.equals(this.itemKey, that.itemKey) && Objects.equals(this.id, that.id) && Objects.equals(this.type, that.type);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(key, id, type);
+    return Objects.hash(itemKey, id, type);
   }
 
   @Override
   public String toString() {
-    return "IdKey[" + "key=" + key + ", " + "id=" + id + ", " + "type=" + type + ']';
+    return "IdKey[" + "itemKey=" + itemKey + ", " + "id=" + id + ", " + "type=" + type + ']';
   }
 
 }

--- a/core/src/main/java/io/camunda/migrator/mapper/IdKeyMapper.java
+++ b/core/src/main/java/io/camunda/migrator/mapper/IdKeyMapper.java
@@ -5,8 +5,9 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.migrator.history;
+package io.camunda.migrator.mapper;
 
+import io.camunda.migrator.history.IdKeyDbModel;
 import java.util.Set;
 import org.apache.ibatis.annotations.Param;
 

--- a/core/src/main/resources/db/changelog/migrator/db.0.0.1.xml
+++ b/core/src/main/resources/db/changelog/migrator/db.0.0.1.xml
@@ -17,12 +17,12 @@
       <column name="ID" type="VARCHAR(64)">
         <constraints primaryKey="true"/>
       </column>
-      <column name="KEY" type="BIGINT" />
+      <column name="ITEM_KEY" type="BIGINT" />
       <column name="TYPE" type="VARCHAR(255)" />
     </createTable>
 
     <createIndex tableName="${prefix}MIGRATION_MAPPING" indexName="${prefix}IDX_MIGRATION_MAPPING_ID">
-      <column name="KEY" />
+      <column name="ITEM_KEY" />
     </createIndex>
   </changeSet>
 

--- a/core/src/main/resources/db/properties/h2.properties
+++ b/core/src/main/resources/db/properties/h2.properties
@@ -1,0 +1,8 @@
+#
+# Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+# one or more contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright ownership.
+# Licensed under the Camunda License 1.0. You may not use this file
+# except in compliance with the Camunda License 1.0.
+#
+paging=LIMIT #{limit} OFFSET #{offset}

--- a/core/src/main/resources/db/properties/h2.properties
+++ b/core/src/main/resources/db/properties/h2.properties
@@ -6,4 +6,4 @@
 # except in compliance with the Camunda License 1.0.
 #
 paging=LIMIT #{limit} OFFSET #{offset}
-paging.first=LIMIT 1
+paging.singleResult=LIMIT 1

--- a/core/src/main/resources/db/properties/h2.properties
+++ b/core/src/main/resources/db/properties/h2.properties
@@ -6,3 +6,4 @@
 # except in compliance with the Camunda License 1.0.
 #
 paging=LIMIT #{limit} OFFSET #{offset}
+paging.first=LIMIT 1

--- a/core/src/main/resources/db/properties/oracle.properties
+++ b/core/src/main/resources/db/properties/oracle.properties
@@ -1,0 +1,10 @@
+#
+# Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+# one or more contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright ownership.
+# Licensed under the Camunda License 1.0. You may not use this file
+# except in compliance with the Camunda License 1.0.
+#
+paging=OFFSET #{offset} ROWS FETCH NEXT #{limit} ROWS ONLY
+
+# https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/SELECT.html

--- a/core/src/main/resources/db/properties/oracle.properties
+++ b/core/src/main/resources/db/properties/oracle.properties
@@ -6,5 +6,7 @@
 # except in compliance with the Camunda License 1.0.
 #
 paging=OFFSET #{offset} ROWS FETCH NEXT #{limit} ROWS ONLY
+paging.first=fetch first 1 rows only
 
 # https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/SELECT.html
+# https://blogs.oracle.com/optimizer/post/fetch-first-rows-just-got-faster

--- a/core/src/main/resources/db/properties/oracle.properties
+++ b/core/src/main/resources/db/properties/oracle.properties
@@ -6,4 +6,4 @@
 # except in compliance with the Camunda License 1.0.
 #
 paging=OFFSET #{offset} ROWS FETCH NEXT #{limit} ROWS ONLY
-paging.first=fetch first 1 rows only
+paging.singleResult=fetch first 1 rows only

--- a/core/src/main/resources/db/properties/oracle.properties
+++ b/core/src/main/resources/db/properties/oracle.properties
@@ -7,6 +7,3 @@
 #
 paging=OFFSET #{offset} ROWS FETCH NEXT #{limit} ROWS ONLY
 paging.first=fetch first 1 rows only
-
-# https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/SELECT.html
-# https://blogs.oracle.com/optimizer/post/fetch-first-rows-just-got-faster

--- a/core/src/main/resources/db/properties/postgresql.properties
+++ b/core/src/main/resources/db/properties/postgresql.properties
@@ -1,0 +1,10 @@
+#
+# Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+# one or more contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright ownership.
+# Licensed under the Camunda License 1.0. You may not use this file
+# except in compliance with the Camunda License 1.0.
+#
+paging=LIMIT #{limit} OFFSET #{offset}
+
+# docs: https://www.postgresql.org/docs/current/queries-limit.html

--- a/core/src/main/resources/db/properties/postgresql.properties
+++ b/core/src/main/resources/db/properties/postgresql.properties
@@ -7,5 +7,3 @@
 #
 paging=LIMIT #{limit} OFFSET #{offset}
 paging.first=LIMIT 1
-
-# docs: https://www.postgresql.org/docs/current/queries-limit.html

--- a/core/src/main/resources/db/properties/postgresql.properties
+++ b/core/src/main/resources/db/properties/postgresql.properties
@@ -6,4 +6,4 @@
 # except in compliance with the Camunda License 1.0.
 #
 paging=LIMIT #{limit} OFFSET #{offset}
-paging.first=LIMIT 1
+paging.singleResult=LIMIT 1

--- a/core/src/main/resources/db/properties/postgresql.properties
+++ b/core/src/main/resources/db/properties/postgresql.properties
@@ -6,5 +6,6 @@
 # except in compliance with the Camunda License 1.0.
 #
 paging=LIMIT #{limit} OFFSET #{offset}
+paging.first=LIMIT 1
 
 # docs: https://www.postgresql.org/docs/current/queries-limit.html

--- a/core/src/main/resources/mapper/Commons.xml
+++ b/core/src/main/resources/mapper/Commons.xml
@@ -16,9 +16,9 @@
     </if>
   </sql>
 
-  <sql id="singlePageSql">
+  <sql id="singleResultSql">
     <if test="limit != null">
-      ${paging.first}
+      ${paging.singleResult}
     </if>
   </sql>
 

--- a/core/src/main/resources/mapper/Commons.xml
+++ b/core/src/main/resources/mapper/Commons.xml
@@ -10,11 +10,11 @@
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="io.camunda.migrator.Commons">
 
-<sql id="pageSql">
-  <if test="limit != null &amp;&amp; offset != null">
-     ${paging}
-  </if>
-</sql>
+  <sql id="pageSql">
+    <if test="limit != null &amp;&amp; offset != null">
+      ${paging}
+    </if>
+  </sql>
 
   <sql id="singlePageSql">
     <if test="limit != null">

--- a/core/src/main/resources/mapper/Commons.xml
+++ b/core/src/main/resources/mapper/Commons.xml
@@ -16,4 +16,10 @@
   </if>
 </sql>
 
+  <sql id="singlePageSql">
+    <if test="limit != null">
+      ${paging.first}
+    </if>
+  </sql>
+
 </mapper>

--- a/core/src/main/resources/mapper/Commons.xml
+++ b/core/src/main/resources/mapper/Commons.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.camunda.migrator.Commons">
+
+<sql id="pageSql">
+  <if test="limit != null &amp;&amp; offset != null">
+     ${paging}
+  </if>
+</sql>
+
+</mapper>

--- a/core/src/main/resources/mapper/IdKey.xml
+++ b/core/src/main/resources/mapper/IdKey.xml
@@ -21,10 +21,7 @@
 
   <sql id="findSkippedProcessInstanceIdsByQueryCriteriaSql">
     SELECT ID FROM ${prefix}MIGRATION_MAPPING WHERE TYPE = 'RUNTIME_PROCESS_INSTANCE' AND `KEY` IS NULL
-    <if test="limit != null &amp;&amp; offset != null">
-      LIMIT #{limit, jdbcType=BIGINT}
-      OFFSET #{offset, jdbcType=BIGINT}
-    </if>
+    <include refid="io.camunda.migrator.Commons.pageSql"/>
   </sql>
 
   <select id="findAllProcessInstanceIds">

--- a/core/src/main/resources/mapper/IdKey.xml
+++ b/core/src/main/resources/mapper/IdKey.xml
@@ -20,7 +20,7 @@
   </select>
 
   <sql id="findSkippedProcessInstanceIdsByQueryCriteriaSql">
-    SELECT ID FROM ${prefix}MIGRATION_MAPPING WHERE TYPE = 'RUNTIME_PROCESS_INSTANCE' AND `KEY` IS NULL
+    SELECT ID FROM ${prefix}MIGRATION_MAPPING WHERE TYPE = 'RUNTIME_PROCESS_INSTANCE' AND KEY IS NULL
     <include refid="io.camunda.migrator.Commons.pageSql"/>
   </sql>
 
@@ -33,7 +33,7 @@
 
   <update id="updateKeyById" parameterType="io.camunda.migrator.history.IdKeyDbModel">
     UPDATE ${prefix}MIGRATION_MAPPING
-    SET `KEY` = #{key, jdbcType=BIGINT}
+    SET KEY = #{key, jdbcType=BIGINT}
     WHERE ID = #{id, jdbcType=VARCHAR}
   </update>
 
@@ -42,20 +42,20 @@
   </select>
 
   <select id="findKeyById" parameterType="java.lang.String">
-    SELECT `KEY` FROM ${prefix}MIGRATION_MAPPING WHERE ID = '${id}' LIMIT 1
+    SELECT KEY FROM ${prefix}MIGRATION_MAPPING WHERE ID = #{id} LIMIT 1
   </select>
 
   <insert
     id="insert"
     parameterType="io.camunda.migrator.history.IdKeyDbModel"
     flushCache="true">
-    INSERT INTO ${prefix}MIGRATION_MAPPING (ID, `KEY`, TYPE)
+    INSERT INTO ${prefix}MIGRATION_MAPPING (ID, KEY, TYPE)
     VALUES (#{id, jdbcType=VARCHAR}, #{key, jdbcType=BIGINT}, #{type, jdbcType=VARCHAR})
   </insert>
 
   <delete id="delete">
     DELETE FROM ${prefix}MIGRATION_MAPPING
-    WHERE ID = '${id}'
+    WHERE ID = #{id}
   </delete>
 
 </mapper>

--- a/core/src/main/resources/mapper/IdKey.xml
+++ b/core/src/main/resources/mapper/IdKey.xml
@@ -39,7 +39,7 @@
 
   <select id="findLatestIdByType" parameterType="java.lang.String">
     SELECT ID FROM ${prefix}MIGRATION_MAPPING WHERE TYPE = '${type}' ORDER BY ID DESC
-    LIMIT 1
+    <include refid="io.camunda.migrator.Commons.singlePageSql"/>
   </select>
 
   <select id="findKeyById" parameterType="java.lang.String">

--- a/core/src/main/resources/mapper/IdKey.xml
+++ b/core/src/main/resources/mapper/IdKey.xml
@@ -20,7 +20,7 @@
   </select>
 
   <sql id="findSkippedProcessInstanceIdsByQueryCriteriaSql">
-    SELECT ID FROM ${prefix}MIGRATION_MAPPING WHERE TYPE = 'RUNTIME_PROCESS_INSTANCE' AND KEY IS NULL
+    SELECT ID FROM ${prefix}MIGRATION_MAPPING WHERE TYPE = 'RUNTIME_PROCESS_INSTANCE' AND ITEM_KEY IS NULL
     <include refid="io.camunda.migrator.Commons.pageSql"/>
   </sql>
 
@@ -33,24 +33,25 @@
 
   <update id="updateKeyById" parameterType="io.camunda.migrator.history.IdKeyDbModel">
     UPDATE ${prefix}MIGRATION_MAPPING
-    SET KEY = #{key, jdbcType=BIGINT}
+    SET ITEM_KEY = #{itemKey, jdbcType=BIGINT}
     WHERE ID = #{id, jdbcType=VARCHAR}
   </update>
 
   <select id="findLatestIdByType" parameterType="java.lang.String">
-    SELECT ID FROM ${prefix}MIGRATION_MAPPING WHERE TYPE = '${type}' ORDER BY ID DESC LIMIT 1
+    SELECT ID FROM ${prefix}MIGRATION_MAPPING WHERE TYPE = '${type}' ORDER BY ID DESC
+    LIMIT 1
   </select>
 
   <select id="findKeyById" parameterType="java.lang.String">
-    SELECT KEY FROM ${prefix}MIGRATION_MAPPING WHERE ID = #{id} LIMIT 1
+    SELECT ITEM_KEY FROM ${prefix}MIGRATION_MAPPING WHERE ID = #{id}
   </select>
 
   <insert
     id="insert"
     parameterType="io.camunda.migrator.history.IdKeyDbModel"
     flushCache="true">
-    INSERT INTO ${prefix}MIGRATION_MAPPING (ID, KEY, TYPE)
-    VALUES (#{id, jdbcType=VARCHAR}, #{key, jdbcType=BIGINT}, #{type, jdbcType=VARCHAR})
+    INSERT INTO ${prefix}MIGRATION_MAPPING (ID, ITEM_KEY, TYPE)
+    VALUES (#{id, jdbcType=VARCHAR}, #{itemKey, jdbcType=BIGINT}, #{type, jdbcType=VARCHAR})
   </insert>
 
   <delete id="delete">

--- a/core/src/main/resources/mapper/IdKey.xml
+++ b/core/src/main/resources/mapper/IdKey.xml
@@ -7,7 +7,7 @@
   ~ except in compliance with the Camunda License 1.0.
   -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="io.camunda.migrator.history.IdKeyMapper">
+<mapper namespace="io.camunda.migrator.mapper.IdKeyMapper">
 
   <select id="findSkippedProcessInstanceIdsCount" resultType="long">
     SELECT COUNT(ID) FROM (

--- a/core/src/main/resources/mapper/IdKey.xml
+++ b/core/src/main/resources/mapper/IdKey.xml
@@ -39,7 +39,7 @@
 
   <select id="findLatestIdByType" parameterType="java.lang.String">
     SELECT ID FROM ${prefix}MIGRATION_MAPPING WHERE TYPE = '${type}' ORDER BY ID DESC
-    <include refid="io.camunda.migrator.Commons.singlePageSql"/>
+    <include refid="io.camunda.migrator.Commons.singleResultSql"/>
   </select>
 
   <select id="findKeyById" parameterType="java.lang.String">

--- a/core/src/test/resources/application.yml
+++ b/core/src/test/resources/application.yml
@@ -1,1 +1,4 @@
 migrator.c7.auto-ddl: true
+camunda:
+  database:
+    database-vendor-id: h2

--- a/examples/create-schemas/pom.xml
+++ b/examples/create-schemas/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>2.3.232</version>
+      <version>${version.h2}</version>
     </dependency>
 
   </dependencies>
@@ -95,7 +95,7 @@
           <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>2.3.232</version>
+            <version>${version.h2}</version>
           </dependency>
         </dependencies>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,8 @@
     <version.spring-boot>3.4.4</version.spring-boot>
     <version.junit.jupiter>5.11.4</version.junit.jupiter>
     <version.java>21</version.java>
+    <version.h2>2.3.232</version.h2>
+    <version.postgresql>42.5.5</version.postgresql>
     <plugin.version.compiler>3.14.0</plugin.version.compiler>
     <plugin.version.nexus-staging>1.6.14</plugin.version.nexus-staging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,6 @@
     <version.junit.jupiter>5.11.4</version.junit.jupiter>
     <version.java>21</version.java>
     <version.h2>2.3.232</version.h2>
-    <version.postgresql>42.5.5</version.postgresql>
     <plugin.version.compiler>3.14.0</plugin.version.compiler>
     <plugin.version.nexus-staging>1.6.14</plugin.version.nexus-staging>
 

--- a/qa/src/main/resources/application.yml
+++ b/qa/src/main/resources/application.yml
@@ -4,3 +4,7 @@ migrator:
 
 logging:
   level.io.camunda.migrator: DEBUG
+
+camunda:
+  database:
+    database-vendor-id: h2

--- a/qa/src/test/java/io/camunda/migrator/qa/RuntimeMigrationAbstractTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/RuntimeMigrationAbstractTest.java
@@ -11,7 +11,7 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.DeploymentEvent;
 import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.migrator.RuntimeMigrator;
-import io.camunda.migrator.history.IdKeyMapper;
+import io.camunda.migrator.mapper.IdKeyMapper;
 import io.camunda.process.test.api.CamundaSpringProcessTest;
 
 import java.util.List;

--- a/qa/src/test/java/io/camunda/migrator/qa/SkipAndRetryProcessInstancesTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/SkipAndRetryProcessInstancesTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureTrue;
 
 import io.camunda.client.api.search.response.ProcessInstance;
-import io.camunda.migrator.history.IdKeyMapper;
+import io.camunda.migrator.mapper.IdKeyMapper;
 import java.util.List;
 import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.TaskService;


### PR DESCRIPTION
* define h2, pg, oracle property files
* load the properties to the databaseProperties bean
* rename `key` to `itemKey` to avoid using reserved words 
* unify syntax for IdKey queries
* create Commons.xml to contain reusable sql
* extract h2 version property in maven
* set default database vendor id to h2
* move package of the mapper

https://github.com/camunda/camunda-bpm-platform/issues/4991