### PR TITLE
chore(validation): add validation for model and element presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ However, even though the C7 Data Migrator is not yet ready for production, we en
 1. Deploy migrated C8 process models and any other required resources such as referenced DMN or forms.
 1. Build or download the distribution.
 1. Start Migrator (start.sh/start.bat) and wait to finish.
+   2. Do not make any changes to the C8 deployments while the migrator is running.
 1. Navigate to Operate and check result.
 1. When a process instance gets skipped, you can start C7 again, modify the process instance into a supported state and shut down C7 again.
 

--- a/core/src/main/java/io/camunda/migrator/RuntimeMigrator.java
+++ b/core/src/main/java/io/camunda/migrator/RuntimeMigrator.java
@@ -246,7 +246,7 @@ public class RuntimeMigrator {
           List<ProcessDefinition> c8Definitions = callApi(c8DefinitionSearchRequest::execute).items();
           if (c8Definitions.isEmpty()) {
             throw new IllegalStateException(
-                String.format("No C8 deployment found for process ID [%s] required for instance with legacyID [%s].",
+                String.format("No C8 process found for process ID [%s] required for instance with legacyID [%s].",
                     c8DefinitionId, legacyProcessInstanceId));
           }
 
@@ -273,7 +273,7 @@ public class RuntimeMigrator {
             // validate element exists in C8 deployment
             if (c8BpmnModelInstance.getModelElementById(flowNode.activityId()) == null) {
               throw new IllegalStateException(String.format(
-                  "C7 instance detected which is currently in a C7 model element which does not exist in the equivalent deployed C8 model. "
+                  "C7 instance detected which is currently in a C7 flow node which does not exist in the equivalent deployed C8 model. "
                       + "Instance legacyId: [%s], Model legacyId: [%s], Element Id: [%s].",
                   legacyProcessInstanceId, c8DefinitionId, flowNode.activityId));
             }

--- a/core/src/main/java/io/camunda/migrator/persistence/IdKeyDbModel.java
+++ b/core/src/main/java/io/camunda/migrator/persistence/IdKeyDbModel.java
@@ -59,7 +59,7 @@ public class IdKeyDbModel {
   }
 
   /**
-   * Type is only set when instane has been skipped.
+   * Type is only set when instance has been skipped.
    */
   public boolean skippedPreviously() {
     return type() != null;

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -42,6 +42,24 @@
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.github.netmikey.logunit</groupId>
+      <artifactId>logunit-core</artifactId>
+      <version>2.0.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+    <groupId>io.github.netmikey.logunit</groupId>
+    <artifactId>logunit-logback</artifactId>
+    <version>2.0.0</version>
+    <exclusions>
+      <exclusion>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+      </exclusion>
+    </exclusions>
+    <scope>test</scope>
+  </dependency>
   </dependencies>
 
   <build>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -49,17 +49,17 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-    <groupId>io.github.netmikey.logunit</groupId>
-    <artifactId>logunit-logback</artifactId>
-    <version>2.0.0</version>
-    <exclusions>
-      <exclusion>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-classic</artifactId>
-      </exclusion>
-    </exclusions>
-    <scope>test</scope>
-  </dependency>
+      <groupId>io.github.netmikey.logunit</groupId>
+      <artifactId>logunit-logback</artifactId>
+      <version>2.0.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-classic</artifactId>
+        </exclusion>
+      </exclusions>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/qa/src/test/java/io/camunda/migrator/qa/ProcessDefinitionNotFoundTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/ProcessDefinitionNotFoundTest.java
@@ -64,20 +64,23 @@ class ProcessDefinitionNotFoundTest extends RuntimeMigrationAbstractTest {
     runtimeMigrator.start();
 
     // then
-    logs.assertContains(String.format(
+    String missingDefinitionLog = String.format(
         "Process instance with legacyId [%s] can't be migrated: "
             + "No C8 deployment found for process ID [%s] required for instance with "
-            + "legacyID [%s].",  c7Instance.getId(), "simpleProcess", c7Instance.getId()));
-    logs.getEvents().clear();
+            + "legacyID [%s].",  c7Instance.getId(), "simpleProcess", c7Instance.getId());
+    long logCountAfterFirstRun = logs.getEvents().stream()
+        .filter(event -> event.getMessage().contains(missingDefinitionLog))
+        .count();
+    assertThat(logCountAfterFirstRun).isEqualTo(1);
 
     // when
     runtimeMigrator.start();
 
-    // then
-    logs.assertContains(String.format(
-        "Process instance with legacyId [%s] can't be migrated: "
-            + "No C8 deployment found for process ID [%s] required for instance with "
-            + "legacyID [%s].",  c7Instance.getId(), "simpleProcess", c7Instance.getId()));
+    // then no additional log entry is created
+    long logCountAfterSecondRun = logs.getEvents().stream()
+        .filter(event -> event.getMessage().contains(missingDefinitionLog))
+        .count();
+    assertThat(logCountAfterSecondRun).isEqualTo(1);
   }
 
 }

--- a/qa/src/test/java/io/camunda/migrator/qa/ProcessDefinitionNotFoundTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/ProcessDefinitionNotFoundTest.java
@@ -11,39 +11,73 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.client.api.command.ClientStatusException;
+import io.camunda.migrator.RuntimeMigrator;
 import io.camunda.migrator.RuntimeMigratorException;
+import io.camunda.migrator.persistence.IdKeyDbModel;
+import io.camunda.migrator.persistence.IdKeyMapper;
+import io.github.netmikey.logunit.api.LogCapturer;
+import java.util.List;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
 
 class ProcessDefinitionNotFoundTest extends RuntimeMigrationAbstractTest {
+
+  @RegisterExtension
+  protected final LogCapturer logs = LogCapturer.create().captureForType(RuntimeMigrator.class);
+
+  @Autowired
+  private IdKeyMapper idKeyMapper;
+
+  @Test
+  public void shouldSkipOnMissingC8Deployment() {
+    // given
+    deployCamunda7Process("io/camunda/migrator/bpmn/c7/simpleProcess.bpmn");
+    var c7Instance = runtimeService.startProcessInstanceByKey("simpleProcess");
+
+    // when
+    runtimeMigrator.start();
+
+    // then
+    logs.assertContains(String.format(
+        "Process instance with legacyId [%s] can't be migrated: "
+            + "No C8 deployment found for process ID [%s] required for instance with "
+            + "legacyID [%s].",  c7Instance.getId(), "simpleProcess", c7Instance.getId()));
+    assertThat(camundaClient.newProcessInstanceSearchRequest().send().join().items().size()).isEqualTo(0);
+    List<IdKeyDbModel> skippedProcessInstanceIds = idKeyMapper.findSkipped().stream().toList();
+    assertThat(skippedProcessInstanceIds.size()).isEqualTo(1);
+    assertThat(skippedProcessInstanceIds.getFirst().id()).isEqualTo(c7Instance.getId());
+  }
 
   @Test
   public void shouldSkipNotExistingProcessIdempotently() {
     // given
     deployCamunda7Process("io/camunda/migrator/bpmn/c7/simpleProcess.bpmn");
-    deployProcessInC7AndC8("userTaskProcess.bpmn");
+   deployProcessInC7AndC8("userTaskProcess.bpmn");
 
-    runtimeService.startProcessInstanceByKey("simpleProcess");
+    var c7Instance = runtimeService.startProcessInstanceByKey("simpleProcess");
     ClockUtil.offset(50_000L);
     runtimeService.startProcessInstanceByKey("userTaskProcessId");
 
-    // assume
-    assertThatExceptionOfType(RuntimeMigratorException.class)
-        .isThrownBy(() -> runtimeMigrator.migrate())
-        .withCauseInstanceOf(ClientStatusException.class)
-        .satisfies(exception ->
-            assertThat(exception.getCause())
-                .hasMessage("Command 'CREATE' rejected with code 'NOT_FOUND': "
-                    + "Expected to find process definition with process ID 'simpleProcess', but none found"));
+    // when
+    runtimeMigrator.start();
 
-    // when repeating the migration, migrator still fails in the same instance.
-    assertThatExceptionOfType(RuntimeMigratorException.class)
-        .isThrownBy(() -> runtimeMigrator.migrate())
-        .withCauseInstanceOf(ClientStatusException.class)
-        .satisfies(exception ->
-            assertThat(exception.getCause())
-                .hasMessage("Command 'CREATE' rejected with code 'NOT_FOUND': "
-                    + "Expected to find process definition with process ID 'simpleProcess', but none found"));
+    // then
+    logs.assertContains(String.format(
+        "Process instance with legacyId [%s] can't be migrated: "
+            + "No C8 deployment found for process ID [%s] required for instance with "
+            + "legacyID [%s].",  c7Instance.getId(), "simpleProcess", c7Instance.getId()));
+    logs.getEvents().clear();
+
+    // when
+    runtimeMigrator.start();
+
+    // then
+    logs.assertContains(String.format(
+        "Process instance with legacyId [%s] can't be migrated: "
+            + "No C8 deployment found for process ID [%s] required for instance with "
+            + "legacyID [%s].",  c7Instance.getId(), "simpleProcess", c7Instance.getId()));
   }
 
 }

--- a/qa/src/test/java/io/camunda/migrator/qa/ProcessElementNotFoundTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/ProcessElementNotFoundTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+package io.camunda.migrator.qa;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import io.camunda.migrator.RuntimeMigrator;
+import io.camunda.migrator.persistence.IdKeyDbModel;
+import io.camunda.migrator.persistence.IdKeyMapper;
+import io.github.netmikey.logunit.api.LogCapturer;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ProcessElementNotFoundTest  extends RuntimeMigrationAbstractTest{
+
+  @RegisterExtension
+  protected final LogCapturer logs = LogCapturer.create().captureForType(RuntimeMigrator.class);
+
+  @Autowired
+  private IdKeyMapper idKeyMapper;
+
+  @Test
+  public void shouldSkipOnMissingElementInC8Deployment() {
+    // given an instance that is currently in an element in the C7 model which does not exist in the C8 model
+    deployProcessInC7AndC8("userTaskProcessWithMissingUserTaskInC8.bpmn");
+    var c7Instance = runtimeService.startProcessInstanceByKey("userTaskProcessWithMissingUserTaskInC8Id");
+
+    // when
+    runtimeMigrator.start();
+
+    // then
+    logs.assertContains(String.format(
+        "Process instance with legacyId [%s] can't be migrated: " +
+            "C7 instance detected which is currently in a C7 model element which does not exist in the equivalent deployed C8 model. "
+            + "Instance legacyId: [%s], Model legacyId: [%s], Element Id: [%s].",
+        c7Instance.getId(), c7Instance.getId(), "userTaskProcessWithMissingUserTaskInC8Id", "userTaskId"));
+    assertThat(camundaClient.newProcessInstanceSearchRequest().send().join().items().size()).isEqualTo(0);
+    List<IdKeyDbModel> skippedProcessInstanceIds = idKeyMapper.findSkipped().stream().toList();
+    assertThat(skippedProcessInstanceIds.size()).isEqualTo(1);
+    assertThat(skippedProcessInstanceIds.getFirst().id()).isEqualTo(c7Instance.getId());
+  }
+
+}

--- a/qa/src/test/java/io/camunda/migrator/qa/ProcessElementNotFoundTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/ProcessElementNotFoundTest.java
@@ -39,7 +39,7 @@ public class ProcessElementNotFoundTest  extends RuntimeMigrationAbstractTest{
     // then
     logs.assertContains(String.format(
         "Process instance with legacyId [%s] can't be migrated: " +
-            "C7 instance detected which is currently in a C7 model element which does not exist in the equivalent deployed C8 model. "
+            "C7 instance detected which is currently in a C7 flow node which does not exist in the equivalent deployed C8 model. "
             + "Instance legacyId: [%s], Model legacyId: [%s], Element Id: [%s].",
         c7Instance.getId(), c7Instance.getId(), "userTaskProcessWithMissingUserTaskInC8Id", "userTaskId"));
     assertThat(camundaClient.newProcessInstanceSearchRequest().send().join().items().size()).isEqualTo(0);

--- a/qa/src/test/java/io/camunda/migrator/qa/SkipAndRetryProcessInstancesTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/SkipAndRetryProcessInstancesTest.java
@@ -15,8 +15,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureTrue;
 
 import io.camunda.client.api.search.response.ProcessInstance;
-import io.camunda.migrator.RuntimeMigrator;
-import io.github.netmikey.logunit.api.LogCapturer;
 import io.camunda.migrator.persistence.IdKeyDbModel;
 import io.camunda.migrator.persistence.IdKeyMapper;
 import java.util.ArrayList;
@@ -28,7 +26,6 @@ import org.camunda.bpm.engine.TaskService;
 import org.camunda.bpm.engine.task.Task;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;

--- a/qa/src/test/java/io/camunda/migrator/qa/SkipAndRetryProcessInstancesTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/SkipAndRetryProcessInstancesTest.java
@@ -15,6 +15,8 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureTrue;
 
 import io.camunda.client.api.search.response.ProcessInstance;
+import io.camunda.migrator.RuntimeMigrator;
+import io.github.netmikey.logunit.api.LogCapturer;
 import io.camunda.migrator.persistence.IdKeyDbModel;
 import io.camunda.migrator.persistence.IdKeyMapper;
 import java.util.ArrayList;
@@ -26,6 +28,7 @@ import org.camunda.bpm.engine.TaskService;
 import org.camunda.bpm.engine.task.Task;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
@@ -34,6 +37,9 @@ import org.springframework.test.context.TestPropertySource;
 @ExtendWith(OutputCaptureExtension.class)
 @TestPropertySource(properties = { "logging.level.io.camunda.migrator=WARN" })
 class SkipAndRetryProcessInstancesTest extends RuntimeMigrationAbstractTest {
+
+  @RegisterExtension
+  protected final LogCapturer logs = LogCapturer.create().captureForType(RuntimeMigrator.class);
 
   @Autowired
   private RuntimeService runtimeService;
@@ -81,6 +87,47 @@ class SkipAndRetryProcessInstancesTest extends RuntimeMigrationAbstractTest {
     List<IdKeyDbModel> skippedProcessInstanceIds = idKeyMapper.findSkipped().stream().toList();
     assertThat(skippedProcessInstanceIds.size()).isEqualTo(1);
     assertThat(skippedProcessInstanceIds.getFirst().id()).isEqualTo(process.getId());
+  }
+
+  @Test
+  public void shouldSkipOnMissingC8Deployment() {
+    // given
+    deployCamunda7Process("io/camunda/migrator/bpmn/c7/simpleProcess.bpmn");
+    var c7Instance = runtimeService.startProcessInstanceByKey("simpleProcess");
+
+    // when
+    runtimeMigrator.start();
+
+    // then
+    logs.assertContains(String.format(
+        "Process instance with legacyId [%s] can't be migrated: "
+            + "No C8 deployment found for process ID [%s] required for instance with "
+            + "legacyID [%s].",  c7Instance.getId(), "simpleProcess", c7Instance.getId()));
+    assertThat(camundaClient.newProcessInstanceSearchRequest().send().join().items().size()).isEqualTo(0);
+    List<IdKeyDbModel> skippedProcessInstanceIds = idKeyMapper.findSkipped().stream().toList();
+    assertThat(skippedProcessInstanceIds.size()).isEqualTo(1);
+    assertThat(skippedProcessInstanceIds.getFirst().id()).isEqualTo(c7Instance.getId());
+  }
+
+  @Test
+  public void shouldSkipOnMissingElementInC8Deployment() {
+    // given an instance that is currently in an element in the C7 model which does not exist in the C8 model
+    deployProcessInC7AndC8("userTaskProcessWithMissingUserTaskInC8.bpmn");
+    var c7Instance = runtimeService.startProcessInstanceByKey("userTaskProcessWithMissingUserTaskInC8Id");
+
+    // when
+    runtimeMigrator.start();
+
+    // then
+    logs.assertContains(String.format(
+        "Process instance with legacyId [%s] can't be migrated: " +
+        "C7 instance detected which is currently in a C7 model element which does not exist in the equivalent deployed C8 model. "
+            + "Instance legacyId: [%s], Model legacyId: [%s], Element Id: [%s].",
+        c7Instance.getId(), c7Instance.getId(), "userTaskProcessWithMissingUserTaskInC8Id", "userTaskId"));
+    assertThat(camundaClient.newProcessInstanceSearchRequest().send().join().items().size()).isEqualTo(0);
+    List<IdKeyDbModel> skippedProcessInstanceIds = idKeyMapper.findSkipped().stream().toList();
+    assertThat(skippedProcessInstanceIds.size()).isEqualTo(1);
+    assertThat(skippedProcessInstanceIds.getFirst().id()).isEqualTo(c7Instance.getId());
   }
 
   @Test

--- a/qa/src/test/resources/io/camunda/migrator/bpmn/c7/userTaskProcessWithMissingUserTaskInC8.bpmn
+++ b/qa/src/test/resources/io/camunda/migrator/bpmn/c7/userTaskProcessWithMissingUserTaskInC8.bpmn
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1a10piy" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.24.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.21.0">
+  <bpmn:process id="userTaskProcessWithMissingUserTaskInC8Id" name="UserTaskProcess" isExecutable="true" camunda:historyTimeToLive="1">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_0xg7od7</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0xg7od7" sourceRef="StartEvent_1" targetRef="userTaskId" />
+    <bpmn:endEvent id="Event_0togu4y" name="End">
+      <bpmn:incoming>Flow_1ur86ut</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1ur86ut" sourceRef="userTaskId" targetRef="Event_0togu4y" />
+    <bpmn:userTask id="userTaskId" name="UserTaskName">
+      <bpmn:incoming>Flow_0xg7od7</bpmn:incoming>
+      <bpmn:outgoing>Flow_1ur86ut</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="userTaskProcessId">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="186" y="142" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0togu4y_di" bpmnElement="Event_0togu4y">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="440" y="142" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0yurv1b_di" bpmnElement="userTaskId">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0xg7od7_di" bpmnElement="Flow_0xg7od7">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ur86ut_di" bpmnElement="Flow_1ur86ut">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/src/test/resources/io/camunda/migrator/bpmn/c8/userTaskProcessWithMissingUserTaskInC8.bpmn
+++ b/qa/src/test/resources/io/camunda/migrator/bpmn/c8/userTaskProcessWithMissingUserTaskInC8.bpmn
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?><bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:conversion="http://camunda.org/schema/conversion/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" conversion:converterVersion="0.12.4" exporter="Camunda Modeler" exporterVersion="5.24.0" expressionLanguage="http://www.w3.org/1999/XPath" id="Definitions_1a10piy" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0" targetNamespace="http://bpmn.io/schema/bpmn" typeLanguage="http://www.w3.org/2001/XMLSchema">
+  <bpmn:process id="userTaskProcessWithMissingUserTaskInC8Id" name="UserTaskProcess" processType="None" isClosed="false" isExecutable="true">
+    <bpmn:extensionElements>
+      <conversion:message severity="INFO">Unused attribute 'historyTimeToLive' on 'process' is removed.</conversion:message>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:extensionElements>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="end" type="migrator" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_0xg7od7</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0xg7od7" sourceRef="StartEvent_1" targetRef="Event_0togu4y" />
+    <bpmn:endEvent id="Event_0togu4y" name="End">
+      <bpmn:incoming>Flow_0xg7od7</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="userTaskProcessWithMissingUserTaskInC8Id">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="186" y="142" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0togu4y_di" bpmnElement="Event_0togu4y">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="440" y="142" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0xg7od7_di" bpmnElement="Flow_0xg7od7">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
related to [#5187](https://github.com/camunda/camunda-bpm-platform/issues/5187)

- I created [this follow up ticket](https://github.com/camunda/camunda-bpm-platform/issues/5241) for future improvements and refactoring of validation logic
- For now, I stuck with the per instance validation logic to keep effort low even though that approach may not be the most performant
- I added a cache to reduce querying for the C8 model multiple times when we have multiple instances from the same model. For future iterations it would be neat to make the cache size configurable, we could also adjust the cache to expire based on size rather than amount of definitions. Since the validation may be refactored a bit anyway I did not invest time into that for now but added a note in the follow up ticket