### PR TITLE
fix(validation): exclude multiInstanceBody ID from unnecessary validation

### DIFF
--- a/core/src/main/java/io/camunda/migrator/RuntimeMigrator.java
+++ b/core/src/main/java/io/camunda/migrator/RuntimeMigrator.java
@@ -302,9 +302,6 @@ public class RuntimeMigrator {
         });
   }
 
-  /**
-   * Validates if flow nodes exist in C8 model.
-   */
   protected void validateC8FlowNodes(BpmnModelInstance c8BpmnModelInstance, String activityId) {
     if (c8BpmnModelInstance.getModelElementById(activityId) == null) {
       throw new IllegalStateException(String.format("Flow node with id [%s] "
@@ -313,7 +310,6 @@ public class RuntimeMigrator {
   }
 
   protected void validateC7FlowNodes(org.camunda.bpm.model.bpmn.BpmnModelInstance c7BpmnModelInstance, String activityId) {
-    // validate no multi-instance loop characteristics
     FlowElement element = c7BpmnModelInstance.getModelElementById(activityId);
     if ((element instanceof Activity activity)
         && (activity.getLoopCharacteristics() instanceof MultiInstanceLoopCharacteristics)) {
@@ -388,7 +384,7 @@ public class RuntimeMigrator {
     Arrays.asList(activityInstance.getChildActivityInstances()).forEach(actInst -> {
       activeActivities.putAll(getActiveActivityIdsById(actInst, activeActivities));
 
-      if (!"subProcess".equals(actInst.getActivityType())) {
+      if (!"subProcess".equals(actInst.getActivityType()) && !actInst.getActivityId().endsWith("#multiInstanceBody") ) {
         activeActivities.put(actInst.getId(), new FlowNode(actInst.getActivityId(), ((ActivityInstanceImpl) actInst).getSubProcessInstanceId()));
       }
     });

--- a/qa/src/test/java/io/camunda/migrator/qa/SkipAndRetryProcessInstancesTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/SkipAndRetryProcessInstancesTest.java
@@ -33,10 +33,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
-import org.springframework.test.context.TestPropertySource;
 
 @ExtendWith(OutputCaptureExtension.class)
-@TestPropertySource(properties = { "logging.level.io.camunda.migrator=WARN" })
 class SkipAndRetryProcessInstancesTest extends RuntimeMigrationAbstractTest {
   private static final String SKIP_INSTANCE_MESSAGE = "Skipping process instance with legacyId [%s]: ";
   private static final String LOOP_CHARACTERISTICS_MESSAGE =


### PR DESCRIPTION
related to [#5264](https://github.com/camunda/camunda-bpm-platform/issues/5264)

See ticket for description of cause.
There would have been a few alternatives of how to fix this, for example always first validating all C7 and then all C8 nodes (rather than both in the same loop), or sorting them pre validation, but I think for now there is no need to validate the "fake" multiInstanceBody node anyway so it seemed the most performant option to exclude it.
Ran locally with n=20 times and all green.
I also tidied up a bit, more specific assertions for test cases and removal of unnecessary coments etc